### PR TITLE
WIP: Additional run_spineopt functionality

### DIFF
--- a/data/spineopt_template.json
+++ b/data/spineopt_template.json
@@ -115,6 +115,7 @@
         ["model", "write_lodf_file", false, "boolean_value_list", "A boolean flag for whether the LODF values should be written to a results file."],
         ["model", "write_mps_file", null, "write_mps_file_list", "A selector for writing an .mps file of the model."],
         ["model", "write_ptdf_file", false, "boolean_value_list", "A boolean flag for whether the LODF values should be written to a results file."],
+        ["model", "write_math_model_file", false, "boolean_value_list", "A boolean flag for whether the mathematical optimization model should be written to a file."],
         ["node", "balance_type", "balance_type_node", "balance_type_list", "A selector for how the `:nodal_balance` constraint should be handled."],
         ["node", "candidate_storages", null, null, "Determines the maximum number of new storages which may be invested in"],
         ["node", "demand", 0.0, null, "Demand for the `commodity` of a `node`. Energy gains can be represented using negative `demand`."],

--- a/src/util/write_information_files.jl
+++ b/src/util/write_information_files.jl
@@ -162,8 +162,16 @@ end
 function print_constraint(constraint, filename="constraint_debug.txt")
     io = open(joinpath(@__DIR__, filename), "w")
     for (inds, con) in constraint
-        print(io, inds, "\n")        
+        print(io, inds, "\n")
         print(io, con, "\n\n")
+    end
+    close(io);
+end
+
+function write_conflicts_to_file(conflicts; file_name="conflicts")
+    io = open(joinpath(@__DIR__, "$(file_name).txt"), "w")
+    for confl in conflicts
+        print(io, confl, "\n")
     end
     close(io);
 end


### PR DESCRIPTION
- for infeasible, direct models, run_spineopt now return the conflicting constraints
- the user can now add variables as key work arguments
- additional write function for conflicts file

Known issues:
@manuelma, when I call any of the write_... functions within SpineOpt, it seems to fail writing them (through console after the run, it works fine)