### PR TITLE
Bug fix: node_injection constraint will only be generated for rep. days

### DIFF
--- a/src/constraints/constraint_nodal_balance.jl
+++ b/src/constraints/constraint_nodal_balance.jl
@@ -58,8 +58,8 @@ function add_constraint_nodal_balance!(m::Model)
             + get(node_slack_pos, (n, s, t), 0) - get(node_slack_neg, (n, s, t), 0),
             eval(nodal_balance_sense(node=n)),
             0,
-        ) for (n, s, t) in node_stochastic_time_indices(m) if balance_type(node=n) !== :balance_type_none &&
-               all(balance_type(node=ng) !== :balance_type_group for ng in groups(n))
+        ) for (n, s, t) in node_injection_indices(m)
+            if balance_type(node=n) !== :balance_type_none && all(balance_type(node=ng) !== :balance_type_group for ng in groups(n))
     )
 end
 

--- a/src/variables/variable_connection_flow.jl
+++ b/src/variables/variable_connection_flow.jl
@@ -38,7 +38,8 @@ function connection_flow_indices(
     temporal_block=temporal_block(representative_periods_mapping=nothing),
 )
     node = members(node)
-    [
+    unique(
+        [
         (connection=conn, node=n, direction=d, stochastic_scenario=s, t=t)
         for (conn, n, d, tb) in connection__node__direction__temporal_block(
             connection=connection,
@@ -53,7 +54,8 @@ function connection_flow_indices(
             temporal_block=tb,
             t=t,
         )
-    ]
+        ]
+    )
 end
 
 """


### PR DESCRIPTION
- as connections flows and node injection variables are mapped, it is sufficient to only constrain them for the rep. periods (the otherones are mapped copies anyways)