### PR TITLE
Fix unit_flow_op for units with more than one direction

### DIFF
--- a/src/variables/variable_unit_flow_op.jl
+++ b/src/variables/variable_unit_flow_op.jl
@@ -43,11 +43,11 @@ function unit_flow_op_indices(
     node = members(node)
     [
         (unit=u, node=n, direction=d, i=i, stochastic_scenario=s, t=t)
-        for (u, n) in indices(operating_points, unit=unit, node=node)
+        for (u, n, d) in indices(operating_points, unit=unit, node=node, direction=direction)
         for (u, n, d, tb) in unit__node__direction__temporal_block(
             unit=u,
             node=n,
-            direction=direction,
+            direction=d,
             temporal_block=temporal_block,
             _compact=false,
         ) for i in intersect(i, 1:length(operating_points(unit=u, node=n, direction=d)))

--- a/test/constraints/constraint_unit.jl
+++ b/test/constraints/constraint_unit.jl
@@ -221,9 +221,12 @@
         operating_points = Dict("type" => "array", "value_type" => "float", "data" => PyVector(points))
         relationship_parameter_values = [
             ["unit__from_node", ["unit_ab", "node_a"], "unit_capacity", unit_capacity],
-            ["unit__from_node", ["unit_ab", "node_a"], "operating_points", operating_points],
+            ["unit__from_node", ["unit_ab", "node_a"], "operating_points", operating_points]
         ]
-        SpineInterface.import_data(url_in; relationship_parameter_values=relationship_parameter_values)
+        relationships = [
+            ["unit__to_node", ["unit_ab", "node_a"]],
+        ]
+        SpineInterface.import_data(url_in; relationship_parameter_values=relationship_parameter_values, relationships=relationships)
 
         m = run_spineopt(url_in; log_level=0, optimize=false)
         var_unit_flow_op = m.ext[:variables][:unit_flow_op]


### PR DESCRIPTION
In one case study, we have a unit that has an operating_point in one direction but not in the other. The previous formulation did not expect a unit to have more than one unit__to_node/from_node relationship. Should be fixed with this merge request