### PR TITLE
Hot fixes bridging gaps

### DIFF
--- a/src/data_structure/temporal_structure.jl
+++ b/src/data_structure/temporal_structure.jl
@@ -422,7 +422,7 @@ function to_time_slice(m::Model; t::TimeSlice)
         for time_slices in values(t_set.block_time_slices)
         for s in _to_time_slice(time_slices, t)
     )
-    in_gaps = isempty(indices(representative_periods_mapping)) ?
+    in_gaps = !isempty(indices(representative_periods_mapping)) ?
         [] : (
         s
         for t_set in t_sets

--- a/src/data_structure/temporal_structure.jl
+++ b/src/data_structure/temporal_structure.jl
@@ -331,9 +331,9 @@ function _generate_representative_time_slice!(m::Model)
                 rep_t_duration = end_(rep_t) - start(rep_t)
                 real_t_end = real_t_start + rep_t_duration
                 merge!(
-                    d, 
+                    d,
                     Dict(
-                        real_t => rep_t 
+                        real_t => rep_t
                         for real_t in to_time_slice(m, t=TimeSlice(real_t_start, real_t_end))
                         if blk in real_t.blocks
                     )
@@ -418,11 +418,12 @@ function to_time_slice(m::Model; t::TimeSlice)
     t_sets = (temp_struct[:time_slice], temp_struct[:history_time_slice])
     in_blocks = (
         s
-        for t_set in t_sets 
+        for t_set in t_sets
         for time_slices in values(t_set.block_time_slices)
         for s in _to_time_slice(time_slices, t)
     )
-    in_gaps = (
+    in_gaps = isempty(indices(representative_periods_mapping)) ?
+        [] : (
         s
         for t_set in t_sets
         for s in _to_time_slice(t_set.gap_bridger.bridges, t_set.gap_bridger.gaps, t)

--- a/src/run_spineopt_sp.jl
+++ b/src/run_spineopt_sp.jl
@@ -364,7 +364,7 @@ function _save_variable_value!(m::Model, name::Symbol, indices::Function)
     var = m.ext[:variables][name]
     m.ext[:values][name] = Dict(
         ind => _variable_value(var[ind])
-        for ind in indices(m; t=vcat(history_time_slice(m), time_slice(m))) # if end_(ind.t) <= end_(current_window(m))
+        for ind in indices(m; t=vcat(history_time_slice(m), time_slice(m)),temporal_block=anything) # if end_(ind.t) <= end_(current_window(m))
     )
 end
 


### PR DESCRIPTION
- The previous implementation of `in_gaps` conflicted with the representatvie period implementation, should work now
- also: outputs are now written for all (not only representative) days. this way e.g. for unit flow's we get a nicer visualization of the evolution over the entire year