### PR TITLE
Bug fix: Include correct stochastic path for this constraint

### DIFF
--- a/src/constraints/constraint_units_available.jl
+++ b/src/constraints/constraint_units_available.jl
@@ -28,7 +28,13 @@ function add_constraint_units_available!(m::Model)
     m.ext[:spineopt].constraints[:units_available] = Dict(
         (unit=u, stochastic_scenario=s, t=t) => @constraint(
             m,
-            +units_available[u, s, t]
+            + expr_sum(
+                +units_available[u, s, t0]
+                for
+                (u, s, t0) in
+                units_on_indices(m; unit=u, stochastic_scenario=s, t=t);
+                init=0,
+            ) #summation only necessary for stochastic_path
             <=
             +unit_availability_factor[(unit=u, stochastic_scenario=s, analysis_time=t0, t=t)] * (
                 +number_of_units[(unit=u, stochastic_scenario=s, analysis_time=t0, t=t)] 
@@ -36,10 +42,37 @@ function add_constraint_units_available!(m::Model)
                     units_invested_available[u, s, t1]
                     for
                     (u, s, t1) in
-                    units_invested_available_indices(m; unit=u, stochastic_scenario=s, t=t_in_t(m; t_short=t));
+                    units_invested_available_indices(m; unit=u, stochastic_scenario=s, t=t_overlaps_t(m; t));
+                    # If t_overlaps_t is chosen here, we don't predefine hierarchy; 
+                    # not crucial, as mostlikely always t_operations < t_investment but could be considered in the future
                     init=0,
                 )
             )
-        ) for (u, s, t) in units_on_indices(m)
+        ) for (u, s, t) in constraint_units_available_indices(m)
     )
+end
+
+"""
+    constraint_units_available_indices(m::Model, unit, t)
+Creates all indices required to include units, stochastic paths and temporals for the `add_constraint_units_available!` constraint generation.
+"""
+function constraint_units_available_indices(m::Model)
+    unique(
+        (unit=u, stochastic_path=path, t=t)
+        for (u,t) in unit_time_indices(m)
+        for path in active_stochastic_paths(
+            unique(ind.stochastic_scenario for ind in _constraint_units_available_indices(m, u, t)),
+        )
+    )
+end
+
+"""
+    _constraint_units_available_indices(m::Model, unit, t)
+An iterator that concatenates `units_on_indices` and `units_invested_available_indices` for the given inputs.
+"""
+function _constraint_units_available_indices(m::Model, unit, node, direction, t)
+    Iterators.flatten((
+        units_on_indices(m; unit=unit, t=t),
+        units_invested_available_indices(m; unit=unit, t=t_overlaps_t(m; t=t)),
+    ))
 end

--- a/src/constraints/constraint_units_available.jl
+++ b/src/constraints/constraint_units_available.jl
@@ -26,7 +26,7 @@ function add_constraint_units_available!(m::Model)
     @fetch units_available, units_invested_available = m.ext[:spineopt].variables
     t0 = _analysis_time(m)
     m.ext[:spineopt].constraints[:units_available] = Dict(
-        (unit=u, stochastic_scenario=s, t=t) => @constraint(
+        (unit=u, stochastic_path=s, t=t) => @constraint(
             m,
             + expr_sum(
                 +units_available[u, s, t0]

--- a/src/constraints/constraint_units_available.jl
+++ b/src/constraints/constraint_units_available.jl
@@ -70,7 +70,7 @@ end
     _constraint_units_available_indices(m::Model, unit, t)
 An iterator that concatenates `units_on_indices` and `units_invested_available_indices` for the given inputs.
 """
-function _constraint_units_available_indices(m::Model, unit, node, direction, t)
+function _constraint_units_available_indices(m::Model, unit, t)
     Iterators.flatten((
         units_on_indices(m; unit=unit, t=t),
         units_invested_available_indices(m; unit=unit, t=t_overlaps_t(m; t=t)),

--- a/test/constraints/constraint_unit.jl
+++ b/test/constraints/constraint_unit.jl
@@ -128,7 +128,8 @@
             var_u_av = var_units_available[key...]
             var_u_inv_av = var_units_invested_available[key...]
             expected_con = @build_constraint(var_u_av - var_u_inv_av <= number_of_units)
-            con = constraint[key...]
+            con_key = (unit(:unit_ab), [s], t)
+            con = constraint[con_key...]
             observed_con = constraint_object(con)
             @test _is_constraint_equal(observed_con, expected_con)
         end


### PR DESCRIPTION
Disclaimer:
Unfortunately, I am a bit pressed for time and don't have time for testing myself. Ideally we would add unit tests e.g. for two-stage stochastic optimization. Current unit tests are passing though. The previous implementation is bugged (see below), so as soon as someone has time to check this, we should merge this quickly.
----
Previously, the investments variable `units_invested_available` would receive the stochastic scenario of the `units_on` variable. However, as investment and operational stochastics are decoupled, different stochastics might be active at different points in time. Now, as we pass all potential paths to the constraint function, we should be able to do this correctly.