### PR TITLE
Bug fix: restore group capacity functionality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           - windows-latest
         arch:
           - x64
+        python-version: '3.9'
           # - x86  # FIXME: We don't support x86 because we type-annotate with Int64 and Float64 sparingly
         exclude:
           # Test 32-bit only on Linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           - windows-latest
         arch:
           - x64
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.9"]
           # - x86  # FIXME: We don't support x86 because we type-annotate with Int64 and Float64 sparingly
         exclude:
           # Test 32-bit only on Linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
       - name: Install spinedb_api
         run:
           julia ./.install_spinedb_api.jl
+        env:
+          PYTHON: python
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,7 @@ jobs:
           - windows-latest
         arch:
           - x64
-        python-version: 
-          - "3.9"
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
           # - x86  # FIXME: We don't support x86 because we type-annotate with Int64 and Float64 sparingly
         exclude:
           # Test 32-bit only on Linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,8 @@ jobs:
           - windows-latest
         arch:
           - x64
-        python-version: '3.9'
+        python-version: 
+          - "3.9"
           # - x86  # FIXME: We don't support x86 because we type-annotate with Int64 and Float64 sparingly
         exclude:
           # Test 32-bit only on Linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
             arch: x86
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9' 
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}

--- a/Project.toml
+++ b/Project.toml
@@ -17,5 +17,5 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SpineInterface = "0cda1612-498a-11e9-3c92-77fa82595a4f"
 
 [compat]
-SpineInterface = "0.8.5"
+SpineInterface = "0.8.6"
 julia = "^1.2"

--- a/src/constraints/constraint_unit_flow_capacity.jl
+++ b/src/constraints/constraint_unit_flow_capacity.jl
@@ -47,20 +47,10 @@ function add_constraint_unit_flow_capacity!(m::Model)
             + expr_sum(
                 (units_on[u, s, t1])
                 * min(duration(t1), duration(t))
+                * unit_capacity[(unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t)]
+                * unit_conv_cap_to_flow[(unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t)]
                 for (u, s, t1) in units_on_indices(m; unit=u, stochastic_scenario=s, t=t_overlaps_t(m; t=t));
                 init=0,
-            )
-            * sum(
-                unit_capacity[(unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t)]
-                * unit_conv_cap_to_flow[(unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t)]
-                for (u, n, d, s, t) in unit_flow_indices(
-                    m;
-                    unit=u,
-                    node=ng,
-                    direction=d,
-                    stochastic_scenario=s,
-                    t=t_in_t(m; t_long=t),
-                )
             )
         ) for (u, ng, d, s, t) in constraint_unit_flow_capacity_indices(m)
     )

--- a/test/run_spineopt.jl
+++ b/test/run_spineopt.jl
@@ -81,7 +81,7 @@ end
             url_in;
             object_parameter_values=object_parameter_values,
             relationship_parameter_values=relationship_parameter_values,
-        )        
+        )
         m = run_spineopt(url_in, url_out; log_level=0)
         con = m.ext[:spineopt].constraints[:unit_flow_capacity]
         using_spinedb(url_out, Y)
@@ -119,7 +119,7 @@ end
             object_parameter_values=object_parameter_values,
             relationship_parameter_values=relationship_parameter_values,
         )
-        
+
         m = run_spineopt(url_in, url_out; log_level=0)
         con = m.ext[:spineopt].constraints[:unit_flow_capacity]
         using_spinedb(url_out, Y)
@@ -161,7 +161,7 @@ end
             relationships=relationships,
             object_parameter_values=object_parameter_values,
             relationship_parameter_values=relationship_parameter_values,
-        )        
+        )
         m = run_spineopt(url_in, url_out; log_level=0)
         @testset for (k, t) in enumerate(time_slice(m))
             ind = first(SpineOpt.units_on_indices(m; t=t))
@@ -207,7 +207,7 @@ end
                 relationships=relationships,
                 object_parameter_values=object_parameter_values,
                 relationship_parameter_values=relationship_parameter_values,
-            )        
+            )
             m = run_spineopt(url_in, url_out; log_level=0)
             nat = unit_flow_non_anticipativity_time(
                 unit=unit(:unit_ab), node=node(:node_b), direction=direction(:to_node)
@@ -261,7 +261,7 @@ end
         # For each analysis time we cover a window of ± 12 hours with `t`,
         # and check that only `t`s within the optimisation window have a `unit_flow` value
         @testset for at in analysis_times, t in at - Hour(12):Hour(1):at + Hour(12)
-            window_start = max(DateTime(2000, 1, 1), at - Hour(1))
+            window_start = max(DateTime(2000, 1, 1), at)
             window_end = min(DateTime(2000, 1, 2), at + Hour(9))
             expected_unit_flow = if window_start <= t < window_end
                 (t < DateTime(2000, 1, 1, 12)) ? 50 : 90
@@ -281,18 +281,18 @@ end
             object_parameter_values=object_parameter_values,
             relationship_parameter_values=relationship_parameter_values,
         )
-        
+
         m = run_spineopt(url_in, url_out; log_level=0)
         @test termination_status(m) != JuMP.MathOptInterface.OPTIMAL
     end
     @testset "unknown output" begin
         _load_test_data(url_in, test_data)
         demand = 100
-        vom_cost = 50        
+        vom_cost = 50
         objects = [["output", "unknown_output"]]
         relationships = [["report__output", ["report_x", "unknown_output"]]]
         object_parameter_values = [
-            ["node", "node_b", "demand", demand]          
+            ["node", "node_b", "demand", demand]
         ]
         relationship_parameter_values = [
             ["unit__to_node", ["unit_ab", "node_b"], "unit_capacity", demand],
@@ -386,7 +386,7 @@ end
         logLevel = 1.0
         ratioGap = 0.015
         demand = 100
-    
+
         mip_solver_options = Dict(
             "type" => "map",
             "index_type" => "str",
@@ -396,7 +396,7 @@ end
                     "index_type" => "str",
                     "data" => Dict(
                         "ratioGap" => ratioGap,
-                        "logLevel" => logLevel,                        
+                        "logLevel" => logLevel,
                     ),
                 ),
             ),
@@ -414,12 +414,12 @@ end
                     ),
                 ),
             ),
-        )         
+        )
 
-        object_parameter_values = [ 
-            ["node", "node_b", "demand", demand],                                    
+        object_parameter_values = [
+            ["node", "node_b", "demand", demand],
             ["model", "instance", "db_mip_solver_options", mip_solver_options],
-            ["model", "instance", "db_lp_solver_options", lp_solver_options]            
+            ["model", "instance", "db_lp_solver_options", lp_solver_options]
         ]
 
         relationship_parameter_values = [["unit__to_node", ["unit_ab", "node_b"], "unit_capacity", demand]]
@@ -428,7 +428,7 @@ end
             object_parameter_values=object_parameter_values,
             relationship_parameter_values=relationship_parameter_values,
         )
-        
+
         m = run_spineopt(url_in, url_out; log_level=0, optimize=false)
         @test get_optimizer_attribute(m, "logLevel") == "1"
         @test get_optimizer_attribute(m, "ratioGap") == "0.015"
@@ -440,7 +440,7 @@ end
         logLevel_master = 0.0
         ratioGap_master = 0.016
         demand = 100
-    
+
         mip_solver_options = Dict(
             "type" => "map",
             "index_type" => "str",
@@ -450,7 +450,7 @@ end
                     "index_type" => "str",
                     "data" => Dict(
                         "ratioGap" => ratioGap,
-                        "logLevel" => logLevel,                        
+                        "logLevel" => logLevel,
                     ),
                 ),
             ),
@@ -468,7 +468,7 @@ end
                     ),
                 ),
             ),
-        )         
+        )
 
         mip_solver_options_master = Dict(
             "type" => "map",
@@ -479,7 +479,7 @@ end
                     "index_type" => "str",
                     "data" => Dict(
                         "ratioGap" => ratioGap_master,
-                        "logLevel" => logLevel_master,                        
+                        "logLevel" => logLevel_master,
                     ),
                 ),
             ),
@@ -502,14 +502,14 @@ end
         objects = [
             ["model", "master_instance"],
             ["temporal_block", "master_hourly"],
-            ["stochastic_structure", "master_deterministic"]            
+            ["stochastic_structure", "master_deterministic"]
         ]
 
-        object_parameter_values = [ 
-            ["node", "node_b", "demand", demand],                                    
+        object_parameter_values = [
+            ["node", "node_b", "demand", demand],
             ["model", "instance", "model_type", "spineopt_standard"],
             ["model", "instance", "db_mip_solver_options", mip_solver_options],
-            ["model", "instance", "db_lp_solver_options", lp_solver_options],            
+            ["model", "instance", "db_lp_solver_options", lp_solver_options],
             ["model", "master_instance", "model_type", "spineopt_benders_master"],
             ["model", "master_instance", "db_mip_solver_options", mip_solver_options_master],
             ["model", "master_instance", "db_lp_solver_options", lp_solver_options_master],
@@ -531,7 +531,7 @@ end
             ["unit__investment_temporal_block", ["unit_ab", "hourly"]],
             ["unit__investment_temporal_block", ["unit_ab", "master_hourly"]],
             ["unit__investment_stochastic_structure", ["unit_ab", "stochastic"]],
-            ["unit__investment_stochastic_structure", ["unit_ab", "master_deterministic"]],            
+            ["unit__investment_stochastic_structure", ["unit_ab", "master_deterministic"]],
         ]
 
         relationship_parameter_values = [["unit__to_node", ["unit_ab", "node_b"], "unit_capacity", demand]]
@@ -542,7 +542,7 @@ end
             object_parameter_values=object_parameter_values,
             relationship_parameter_values=relationship_parameter_values,
         )
-        
+
         (m, mp) = run_spineopt(url_in, url_out; log_level=0, optimize=false)
         @test get_optimizer_attribute(m, "logLevel") == "1"
         @test get_optimizer_attribute(m, "ratioGap") == "0.015"
@@ -571,7 +571,7 @@ end
             relationships=relationships,
             object_parameter_values=object_parameter_values,
             relationship_parameter_values=relationship_parameter_values,
-        )        
+        )
         m = run_spineopt(url_in, url_out; log_level=0)
         SpineOpt.update_model!(m)  # So that history is fixed
         history_end = model_end(model=m.ext[:spineopt].instance) - roll_forward(model=m.ext[:spineopt].instance)
@@ -608,7 +608,7 @@ end
             relationships=relationships,
             object_parameter_values=object_parameter_values,
             relationship_parameter_values=relationship_parameter_values,
-        )        
+        )
         rm(file_path_out; force=true)
         m = run_spineopt(url_in, url_out; log_level=0)
         using_spinedb(url_out, Y)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,12 +17,14 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #############################################################################
 
+using Revise
 using SpineOpt
 using SpineInterface
 using Test
 using Dates
 using JuMP
 using PyCall
+
 
 import SpineOpt:
     time_slice,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,7 +17,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #############################################################################
 
-using Revise
 using SpineOpt
 using SpineInterface
 using Test


### PR DESCRIPTION
This bug was introduced in commit 1a14541933fa0d58189ffb3c5a662dac97e15835 after a series of other adaption. Mainly we summed up the unit_capacity for each unit_flow, while it should be the sum of unit_flows that is constrained by one shared unit_capacity parameter. Bottom line we now retrieve the stochastic scenario for the unit_capacity parameter from the units_on variable again, to restore functionlaity. #483 discusses the problem for other cases