### PR TITLE
Introduce has_free_start and use it to create blocks private history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ Manifest.toml
 
 .vscode/
 debugging/
+deleteme.sqlite

--- a/examples/capacity_planning.json
+++ b/examples/capacity_planning.json
@@ -3608,6 +3608,13 @@
         ],
         [
             "temporal_block",
+            "has_free_start",
+            false,
+            "boolean_value_list",
+            "Whether the block requires a fresh start (own independent history)"
+        ],
+        [
+            "temporal_block",
             "is_active",
             true,
             "boolean_value_list",

--- a/examples/multi-year_investment_with_econ_discounting_consecutives.json
+++ b/examples/multi-year_investment_with_econ_discounting_consecutives.json
@@ -3431,6 +3431,13 @@
         ],
         [
             "temporal_block",
+            "has_free_start",
+            false,
+            "boolean_value_list",
+            "Whether the block requires a fresh start (own independent history)"
+        ],
+        [
+            "temporal_block",
             "is_active",
             true,
             "boolean_value_list",

--- a/examples/multi-year_investment_with_econ_discounting_milestones.json
+++ b/examples/multi-year_investment_with_econ_discounting_milestones.json
@@ -3503,6 +3503,13 @@
         ],
         [
             "temporal_block",
+            "has_free_start",
+            false,
+            "boolean_value_list",
+            "Whether the block requires a fresh start (own independent history)"
+        ],
+        [
+            "temporal_block",
             "is_active",
             true,
             "boolean_value_list",

--- a/examples/multi-year_investment_without_econ_discounting.json
+++ b/examples/multi-year_investment_without_econ_discounting.json
@@ -3424,6 +3424,13 @@
         ],
         [
             "temporal_block",
+            "has_free_start",
+            false,
+            "boolean_value_list",
+            "Whether the block requires a fresh start (own independent history)"
+        ],
+        [
+            "temporal_block",
             "is_active",
             true,
             "boolean_value_list",

--- a/examples/reserves.json
+++ b/examples/reserves.json
@@ -2152,6 +2152,13 @@
         ],
         [
             "temporal_block",
+            "has_free_start",
+            false,
+            "boolean_value_list",
+            "Whether the block requires a fresh start (own independent history)"
+        ],
+        [
+            "temporal_block",
             "is_active",
             true,
             "boolean_value_list",

--- a/examples/rolling_horizon.json
+++ b/examples/rolling_horizon.json
@@ -2152,6 +2152,13 @@
         ],
         [
             "temporal_block",
+            "has_free_start",
+            false,
+            "boolean_value_list",
+            "Whether the block requires a fresh start (own independent history)"
+        ],
+        [
+            "temporal_block",
             "is_active",
             true,
             "boolean_value_list",

--- a/examples/simple_system.json
+++ b/examples/simple_system.json
@@ -2152,6 +2152,13 @@
         ],
         [
             "temporal_block",
+            "has_free_start",
+            false,
+            "boolean_value_list",
+            "Whether the block requires a fresh start (own independent history)"
+        ],
+        [
+            "temporal_block",
             "is_active",
             true,
             "boolean_value_list",

--- a/examples/stochastic.json
+++ b/examples/stochastic.json
@@ -3438,6 +3438,13 @@
         ],
         [
             "temporal_block",
+            "has_free_start",
+            false,
+            "boolean_value_list",
+            "Whether the block requires a fresh start (own independent history)"
+        ],
+        [
+            "temporal_block",
             "is_active",
             true,
             "boolean_value_list",

--- a/examples/unit_commitment.json
+++ b/examples/unit_commitment.json
@@ -2152,6 +2152,13 @@
         ],
         [
             "temporal_block",
+            "has_free_start",
+            false,
+            "boolean_value_list",
+            "Whether the block requires a fresh start (own independent history)"
+        ],
+        [
+            "temporal_block",
             "is_active",
             true,
             "boolean_value_list",

--- a/src/constraints/constraint_cyclic_node_state.jl
+++ b/src/constraints/constraint_cyclic_node_state.jl
@@ -57,7 +57,8 @@ function constraint_cyclic_node_state_indices(m::Model)
         for (n, blk) in indices(cyclic_condition)
         if cyclic_condition(node=n, temporal_block=blk)
         for t_start in filter(
-            x -> blk in blocks(x), t_before_t(m; t_after=first(collect(time_slice(m; temporal_block=members(blk)))))
+            x -> blk in blocks(x) && x ∉ history_time_slice(m; temporal_block=blk), 
+            t_before_t(m; t_after=first(collect(time_slice(m; temporal_block=members(blk)))))
         )
         for t_end in last(collect(time_slice(m; temporal_block=members(blk))))
         for path in active_stochastic_paths(m, node_state_indices(m; node=n, t=[t_start, t_end]))

--- a/src/constraints/constraint_cyclic_node_state.jl
+++ b/src/constraints/constraint_cyclic_node_state.jl
@@ -56,17 +56,9 @@ function constraint_cyclic_node_state_indices(m::Model)
         (node=n, stochastic_path=path, t_start=t_start, t_end=t_end, temporal_block=blk)
         for (n, blk) in indices(cyclic_condition)
         if cyclic_condition(node=n, temporal_block=blk)
-        for t_start in if has_free_start(temporal_block=blk)
-            filter(
-                x -> blk in blocks(x) && x ∉ history_time_slice(m; temporal_block=blk),
-                t_before_t(m; t_after=first(collect(time_slice(m; temporal_block=members(blk)))))
-            )
-        else
-            filter(
-                x -> blk in blocks(x),
-                t_before_t(m; t_after=first(collect(time_slice(m; temporal_block=members(blk)))))
-            )
-        end
+        for t_start in filter(
+            x -> blk in blocks(x), t_before_t(m; t_after=first(collect(time_slice(m; temporal_block=members(blk)))))
+        )
         for t_end in last(collect(time_slice(m; temporal_block=members(blk))))
         for path in active_stochastic_paths(m, node_state_indices(m; node=n, t=[t_start, t_end]))
     )

--- a/src/constraints/constraint_cyclic_node_state.jl
+++ b/src/constraints/constraint_cyclic_node_state.jl
@@ -56,10 +56,17 @@ function constraint_cyclic_node_state_indices(m::Model)
         (node=n, stochastic_path=path, t_start=t_start, t_end=t_end, temporal_block=blk)
         for (n, blk) in indices(cyclic_condition)
         if cyclic_condition(node=n, temporal_block=blk)
-        for t_start in filter(
-            x -> blk in blocks(x) && x ∉ history_time_slice(m; temporal_block=blk), 
-            t_before_t(m; t_after=first(collect(time_slice(m; temporal_block=members(blk)))))
-        )
+        for t_start in if has_free_start(temporal_block=blk)
+            filter(
+                x -> blk in blocks(x) && x ∉ history_time_slice(m; temporal_block=blk),
+                t_before_t(m; t_after=first(collect(time_slice(m; temporal_block=members(blk)))))
+            )
+        else
+            filter(
+                x -> blk in blocks(x),
+                t_before_t(m; t_after=first(collect(time_slice(m; temporal_block=members(blk)))))
+            )
+        end
         for t_end in last(collect(time_slice(m; temporal_block=members(blk))))
         for path in active_stochastic_paths(m, node_state_indices(m; node=n, t=[t_start, t_end]))
     )

--- a/src/data_structure/temporal_structure.jl
+++ b/src/data_structure/temporal_structure.jl
@@ -201,16 +201,35 @@ function _required_history_duration(m)
 end
 
 function _history_time_slices(m, window_start, window_end, window_time_slices)
-    window_duration = window_end - window_start
     required_history_duration = _required_history_duration(m)
-    history_start = window_start - required_history_duration
-    history_window_count = div(Minute(required_history_duration), Minute(window_duration), RoundUp)
+    # First, compute mappings from history interval to
+    # (i) all the corresponding window time slices, and
+    # (ii) the snapshot duration
+    # (iii) the history start
     time_slices_by_history_interval = Dict()
+    snapshot_duration_by_history_interval = Dict()
+    history_start_by_history_interval = Dict()
     for t in window_time_slices
-        t_start, t_end = start(t), min(end_(t), window_end)
+        snapshots = [blk for blk in blocks(t) if is_snapshot(temporal_block=blk)]
+        snapshot_start, snapshot_end = if length(snapshots) > 1
+            error("timeslice $t is in more than one snapshot: $snapshots")
+        elseif length(snapshots) == 1
+            snapshot = only(snapshots)
+            snapshot_start = _adjusted_start(window_start, block_start(temporal_block=snapshot, _strict=false))
+            snapshot_end = _adjusted_end(window_start, window_end, block_end(temporal_block=snapshot, _strict=false))
+            snapshot_start, snapshot_end
+        else
+            window_start, window_end
+        end
+        t_start, t_end = start(t), min(end_(t), snapshot_end)
         t_start < t_end || continue
-        push!(get!(time_slices_by_history_interval, (t_start, t_end) .- window_duration, Set()), t)
+        snapshot_duration = snapshot_end - snapshot_start
+        history_interval = (t_start, t_end) .- snapshot_duration
+        push!(get!(time_slices_by_history_interval, history_interval, Set()), t)
+        snapshot_duration_by_history_interval[history_interval] = snapshot_duration
+        history_start_by_history_interval[history_interval] = snapshot_start - required_history_duration
     end
+    # Compute mapping from history interval to history time slice
     history_t_by_interval = Dict(
         (t_start, t_end) => TimeSlice(
             t_start,
@@ -220,22 +239,23 @@ function _history_time_slices(m, window_start, window_end, window_time_slices)
         )
         for ((t_start, t_end), time_slices) in time_slices_by_history_interval
     )
+    # Collect all history time slices
+    history_time_slices = Array{TimeSlice,1}()
+    for (history_interval, history_t) in history_t_by_interval
+        while end_(history_t) > history_start_by_history_interval[history_interval]
+            pushfirst!(history_time_slices, history_t)
+            history_t -= snapshot_duration_by_history_interval[history_interval]
+        end
+    end
+    # Compute mapping from window time slice to corresponding history time slice
+    # Note that more than one window time slice can map to the same history time slice
     t_history_t = Dict(
         t => history_t_by_interval[t_start, t_end]
         for ((t_start, t_end), time_slices) in time_slices_by_history_interval
-        if t_end > history_start
+        if t_end > history_start_by_history_interval[t_start, t_end]
         for t in time_slices
     )
-    history_window_time_slices = collect(values(history_t_by_interval))
-    sort!(history_window_time_slices)
-    history_time_slices = Array{TimeSlice,1}()
-    for k in Iterators.countfrom(1)
-        prepend!(history_time_slices, history_window_time_slices)
-        k == history_window_count && break
-        history_window_time_slices .-= window_duration
-    end
-    filter!(t -> end_(t) > history_start, history_time_slices)
-    history_time_slices, t_history_t
+    sort!(history_time_slices), t_history_t
 end
 
 """

--- a/src/objective/connection_flow_costs.jl
+++ b/src/objective/connection_flow_costs.jl
@@ -37,7 +37,8 @@ function connection_flow_costs(m::Model, t_range)
             * connection_flow_cost(m; connection=conn, node=n, direction=d, stochastic_scenario=s, t=t)
             * node_stochastic_scenario_weight(m; node=n, stochastic_scenario=s)
             for (conn, n, d) in indices(connection_flow_cost)
-            for (conn, n, d, s, t) in connection_flow_indices(m; connection=conn, node=n, direction=d, t=t_range);
+            for (conn, n, d, s, t) in connection_flow_indices(m; connection=conn, node=n, direction=d, t=t_range)
+            if t ∉ history_time_slice(m, temporal_block=anything, t=anything) ;
             init=0,
         )
     )

--- a/src/objective/variable_om_costs.jl
+++ b/src/objective/variable_om_costs.jl
@@ -37,7 +37,8 @@ function variable_om_costs(m::Model, t_range)
             * vom_cost(m; unit=ug, node=ng, direction=d, stochastic_scenario=s, t=t)
             * node_stochastic_scenario_weight(m; node=ng, stochastic_scenario=s)
             for (ug, ng, d) in indices(vom_cost)
-            for (u, n, d, s, t) in unit_flow_indices(m; unit=ug, node=ng, direction=d, t=t_range);
+            for (u, n, d, s, t) in unit_flow_indices(m; unit=ug, node=ng, direction=d, t=t_range)
+            if t ∉ history_time_slice(m, temporal_block=anything, t=anything);
             init=0,
         )
     )

--- a/templates/spineopt_template.json
+++ b/templates/spineopt_template.json
@@ -278,6 +278,7 @@
         ["stage", "stage_scenario", null, null, "The scenario that this `stage` should run (EXPERIMENTAL)."],
         ["temporal_block", "block_end", null, null, "The end time for the `temporal_block`. Can be given either as a `DateTime` for a static end point, or as a `Duration` for an end point relative to the start of the current optimization."],
         ["temporal_block", "block_start", null, null, "The start time for the `temporal_block`. Can be given either as a `DateTime` for a static start point, or as a `Duration` for an start point relative to the start of the current optimization."],
+        ["temporal_block", "is_snapshot", false, "boolean_value_list", "Whether the block requires a fresh start (own independent history)"],
         ["temporal_block", "representative_period_index", null, null, "Index for the array of coefficients defined in `representative_periods_mapping`"],
         ["temporal_block", "representative_periods_mapping", null, null, "Map from date time to representative temporal block combination (either a single block's name, or an array of coefficients for each block that has a `representative_period_index`)"],
         ["temporal_block", "resolution", {"type": "duration", "data": "1h"}, null, "Temporal resolution of the `temporal_block`. Essentially, divides the period between `block_start` and `block_end` into `TimeSlices` with the input `resolution`."],

--- a/templates/spineopt_template.json
+++ b/templates/spineopt_template.json
@@ -278,7 +278,7 @@
         ["stage", "stage_scenario", null, null, "The scenario that this `stage` should run (EXPERIMENTAL)."],
         ["temporal_block", "block_end", null, null, "The end time for the `temporal_block`. Can be given either as a `DateTime` for a static end point, or as a `Duration` for an end point relative to the start of the current optimization."],
         ["temporal_block", "block_start", null, null, "The start time for the `temporal_block`. Can be given either as a `DateTime` for a static start point, or as a `Duration` for an start point relative to the start of the current optimization."],
-        ["temporal_block", "is_snapshot", false, "boolean_value_list", "Whether the block requires a fresh start (own independent history)"],
+        ["temporal_block", "has_free_start", false, "boolean_value_list", "Whether the block requires a fresh start (own independent history)"],
         ["temporal_block", "representative_period_index", null, null, "Index for the array of coefficients defined in `representative_periods_mapping`"],
         ["temporal_block", "representative_periods_mapping", null, null, "Map from date time to representative temporal block combination (either a single block's name, or an array of coefficients for each block that has a `representative_period_index`)"],
         ["temporal_block", "resolution", {"type": "duration", "data": "1h"}, null, "Temporal resolution of the `temporal_block`. Essentially, divides the period between `block_start` and `block_end` into `TimeSlices` with the input `resolution`."],

--- a/test/constraints/constraint_node.jl
+++ b/test/constraints/constraint_node.jl
@@ -1103,41 +1103,53 @@ function test_constraint_free_start_node_state()
         url_in = _test_constraint_node_setup()
         objects = [["temporal_block","discontinuous_block"]]
         object_parameter_values = [
-            ["temporal_block","discontinuous_block","has_free_start", true],
-            ["temporal_block","discontinuous_block","resolution", Dict("type"=>"duration","data"=>"1h")],
-            ["temporal_block","discontinuous_block","block_start", Dict("type" => "date_time", "data" => "2000-01-02T00:00:00")],
-            ["temporal_block","discontinuous_block","block_end", Dict("type" => "date_time", "data" => "2000-01-02T02:00:00")],
-            ["node","node_b","has_state", true],
-            ["node","node_b","node_state_cap", 100.0],
-            ["node","node_b","initial_node_state", 50.0],
-            #["temporal_block","hourly","has_free_start", true],
-            ["temporal_block","hourly","block_end", Dict("type" => "date_time", "data" => "2000-01-01T02:00:00")],
-            ["temporal_block","two_hourly","block_end", Dict("type" => "date_time", "data" => "2000-01-01T02:00:00")],
-            ["temporal_block", "investments_hourly", "block_end", Dict("type" => "date_time", "data" => "2000-01-01T02:00:00")],
-            ["model", "instance", "model_end", Dict("type" => "date_time", "data" => "2000-01-02T02:00:00")],
+            ["temporal_block", "discontinuous_block", "has_free_start", true],
+            ["temporal_block", "discontinuous_block", "resolution", unparse_db_value(Hour(1))],
+            ["temporal_block", "discontinuous_block", "block_start", unparse_db_value(DateTime("2000-01-02T00:00:00"))],
+            ["temporal_block", "discontinuous_block", "block_end", unparse_db_value(DateTime("2000-01-02T02:00:00"))],
+            ["node", "node_b", "has_state", true],
+            ["node", "node_b", "node_state_cap", 100.0],
+            ["node", "node_b", "initial_node_state", 50.0],
+            ["temporal_block", "hourly", "has_free_start", true],
+            ["temporal_block", "hourly", "block_end", unparse_db_value(DateTime("2000-01-01T02:00:00"))],
+            ["temporal_block", "two_hourly", "block_end", unparse_db_value(DateTime("2000-01-01T02:00:00"))],
+            ["temporal_block", "investments_hourly", "block_end", unparse_db_value(DateTime("2000-01-01T02:00:00"))],
+            ["model", "instance", "model_end", unparse_db_value(DateTime("2000-01-02T02:00:00"))],
         ]
         relationships = [
-            ["model__temporal_block", ["instance", "discontinuous_block"]],
-            ["node__temporal_block", ["node_b","discontinuous_block"]],
+            ["node__temporal_block", ["node_b", "discontinuous_block"]],
         ]
-
-        # FOR COMPARISON AND TESTING (DELETE ME BEFORE MERGING)
-        #url_in = _test_constraint_node_setup()
-        #objects = []
-        #object_parameter_values = [
-        #    ["node","node_b","has_state", true],
-        #    ["node","node_b","node_state_cap", 100.0],
-        #    ["node","node_b","initial_node_state", 50.0],
-        #    ["temporal_block","hourly","block_end", Dict("type" => "date_time", "data" => "2000-01-01T02:00:00")],
-        #    ["temporal_block","two_hourly","block_end", Dict("type" => "date_time", "data" => "2000-01-01T02:00:00")],
-        #    ["temporal_block", "investments_hourly", "block_end", Dict("type" => "date_time", "data" => "2000-01-01T02:00:00")],
-        #]
-        #relationships = []
-
-        SpineInterface.import_data(url_in; objects=objects, object_parameter_values=object_parameter_values, relationships=relationships)
+        SpineInterface.import_data(
+            url_in; objects=objects, object_parameter_values=object_parameter_values, relationships=relationships
+         )
         m = run_spineopt(url_in; log_level=0, optimize=false)
-        @test history_time_slice(m) |> length == 1
-
+        # Check we have the middle history node_state variable
+        var_n_state = m.ext[:spineopt].variables[:node_state]
+        middle_history_t = only(history_time_slice(m; temporal_block=temporal_block(:discontinuous_block)))
+        middle_history_ind = (node=node(:node_b), stochastic_scenario=stochastic_scenario(:parent), t=middle_history_t)
+        @test middle_history_ind in keys(var_n_state)
+        # Check we have the right node_injection constraint at the discontinuity
+        con_n_inj = m.ext[:spineopt].constraints[:node_injection]
+        t_before = middle_history_t
+        t_after = first(time_slice(m; temporal_block=temporal_block(:discontinuous_block)))
+        discont_ind = (
+            node=node(:node_b),
+            stochastic_path=stochastic_scenario.([:parent, :child]),
+            t_before=t_before,
+            t_after=t_after,
+        )
+        @test discont_ind in keys(con_n_inj)
+        observed_con = constraint_object(con_n_inj[discont_ind])
+        var_n_inj = m.ext[:spineopt].variables[:node_injection]
+        var_u_flow = m.ext[:spineopt].variables[:unit_flow]
+        expected_con = @build_constraint(
+            + var_n_inj[node(:node_b), stochastic_scenario(:child), t_after]
+            + var_n_state[node(:node_b), stochastic_scenario(:child), t_after]
+            - var_n_state[node(:node_b), stochastic_scenario(:parent), t_before]
+            - var_u_flow[unit(:unit_ab), node(:node_b), direction(:to_node), stochastic_scenario(:child), t_after]
+            == 0
+        )
+        @test _is_constraint_equal(observed_con, expected_con)
     end
 end
 

--- a/test/constraints/constraint_node.jl
+++ b/test/constraints/constraint_node.jl
@@ -1098,6 +1098,48 @@ function test_constraint_min_capacity_margin_penalty()
     end
 end
 
+function test_constraint_free_start_node_state()
+    @testset "constraint_free_start_node_state" begin
+        url_in = _test_constraint_node_setup()
+        objects = [["temporal_block","discontinuous_block"]]
+        object_parameter_values = [
+            ["temporal_block","discontinuous_block","has_free_start", true],
+            ["temporal_block","discontinuous_block","resolution", Dict("type"=>"duration","data"=>"1h")],
+            ["temporal_block","discontinuous_block","block_start", Dict("type" => "date_time", "data" => "2000-01-02T00:00:00")],
+            ["temporal_block","discontinuous_block","block_end", Dict("type" => "date_time", "data" => "2000-01-02T02:00:00")],
+            ["node","node_b","has_state", true],
+            ["node","node_b","node_state_cap", 100.0],
+            ["node","node_b","initial_node_state", 50.0],
+            #["temporal_block","hourly","has_free_start", true],
+            ["temporal_block","hourly","block_end", Dict("type" => "date_time", "data" => "2000-01-01T02:00:00")],
+            ["temporal_block","two_hourly","block_end", Dict("type" => "date_time", "data" => "2000-01-01T02:00:00")],
+            ["temporal_block", "investments_hourly", "block_end", Dict("type" => "date_time", "data" => "2000-01-01T02:00:00")],
+            ["model", "instance", "model_end", Dict("type" => "date_time", "data" => "2000-01-02T02:00:00")],
+        ]
+        relationships = [
+            ["model__temporal_block", ["instance", "discontinuous_block"]],
+            ["node__temporal_block", ["node_b","discontinuous_block"]],
+        ]
+
+        # FOR COMPARISON AND TESTING (DELETE ME BEFORE MERGING)
+        #url_in = _test_constraint_node_setup()
+        #objects = []
+        #object_parameter_values = [
+        #    ["node","node_b","has_state", true],
+        #    ["node","node_b","node_state_cap", 100.0],
+        #    ["node","node_b","initial_node_state", 50.0],
+        #    ["temporal_block","hourly","block_end", Dict("type" => "date_time", "data" => "2000-01-01T02:00:00")],
+        #    ["temporal_block","two_hourly","block_end", Dict("type" => "date_time", "data" => "2000-01-01T02:00:00")],
+        #    ["temporal_block", "investments_hourly", "block_end", Dict("type" => "date_time", "data" => "2000-01-01T02:00:00")],
+        #]
+        #relationships = []
+
+        SpineInterface.import_data(url_in; objects=objects, object_parameter_values=object_parameter_values, relationships=relationships)
+        m = run_spineopt(url_in; log_level=0, optimize=false)
+        @test history_time_slice(m) |> length == 1
+
+    end
+end
 
 @testset "node-based constraints" begin
     test_constraint_nodal_balance()
@@ -1121,4 +1163,5 @@ end
     test_constraint_storage_lifetime_mp()
     test_constraint_min_capacity_margin()
     test_constraint_min_capacity_margin_penalty()
+    test_constraint_free_start_node_state()
 end

--- a/test/data_structure/migration.jl
+++ b/test/data_structure/migration.jl
@@ -382,7 +382,6 @@ function _test_translate_use_economic_representation__use_milestone_years()
 				"query",
 				("list_value_sq", "parameter_value_list_sq"),
 			)
-			@show collect(_check)
 
 			old_parameter_names = [:use_economic_representation, :use_milestone_years]
 			new_parameter_name = :multiyear_economic_discounting

--- a/test/data_structure/temporal_structure.jl
+++ b/test/data_structure/temporal_structure.jl
@@ -475,8 +475,8 @@ function _test_master_temporal_structure()
     end
 end
 
-function _test_snapshots()
-    @testset "snapshots" begin
+function _test_subwindows()
+    @testset "subwindows" begin
         url_in = _test_temporal_structure_setup()
         res = Day(1)
         m_start = DateTime(2001, 1, 1)
@@ -485,8 +485,8 @@ function _test_snapshots()
         object_parameter_values = [
             ["model", "instance", "model_start", unparse_db_value(m_start)],
             ["model", "instance", "model_end", unparse_db_value(m_end)],
-            ["temporal_block", "block_a", "is_snapshot", true],
-            ["temporal_block", "block_b", "is_snapshot", true],
+            ["temporal_block", "block_a", "has_free_start", true],
+            ["temporal_block", "block_b", "has_free_start", true],
             ["temporal_block", "block_a", "resolution", unparse_db_value(res)],
             ["temporal_block", "block_b", "resolution", unparse_db_value(res)],
             ["temporal_block", "block_a", "block_start", unparse_db_value(m_start)],
@@ -531,5 +531,5 @@ end
     _test_to_time_slice_with_rolling()
     _test_history()
     _test_master_temporal_structure()
-    _test_snapshots()
+    _test_subwindows()
 end

--- a/test/data_structure/temporal_structure.jl
+++ b/test/data_structure/temporal_structure.jl
@@ -41,8 +41,6 @@ function _test_temporal_structure_setup()
             ["temporal_block", "block_b"],
         ],
         :relationships => [
-            ["model__temporal_block", ["instance", "block_a"]],
-            ["model__temporal_block", ["instance", "block_b"]],
             ["node__temporal_block", ["only_node", "block_a"]],
             ["node__temporal_block", ["only_node", "block_b"]],
         ],
@@ -477,6 +475,51 @@ function _test_master_temporal_structure()
     end
 end
 
+function _test_snapshots()
+    @testset "snapshots" begin
+        url_in = _test_temporal_structure_setup()
+        res = Day(1)
+        m_start = DateTime(2001, 1, 1)
+        m_end = m_start + Week(1)
+        objects = [["temporal_block", "long_block"]]
+        object_parameter_values = [
+            ["model", "instance", "model_start", unparse_db_value(m_start)],
+            ["model", "instance", "model_end", unparse_db_value(m_end)],
+            ["temporal_block", "block_a", "is_snapshot", true],
+            ["temporal_block", "block_b", "is_snapshot", true],
+            ["temporal_block", "block_a", "resolution", unparse_db_value(res)],
+            ["temporal_block", "block_b", "resolution", unparse_db_value(res)],
+            ["temporal_block", "block_a", "block_start", unparse_db_value(m_start)],
+            ["temporal_block", "block_a", "block_end", unparse_db_value(m_start + Day(1))],
+            ["temporal_block", "block_b", "block_start", unparse_db_value(m_start + Day(3))],
+            ["temporal_block", "block_b", "block_end", unparse_db_value(m_start + Day(4))],
+            ["temporal_block", "long_block", "resolution", unparse_db_value(Week(1))],
+        ]
+        SpineInterface.import_data(url_in; objects=objects, object_parameter_values=object_parameter_values)
+        using_spinedb(url_in, SpineOpt)
+        m = _model()
+        SpineOpt.generate_temporal_structure!(m)
+        obs_time_slices = time_slice(m)
+        exp_time_slices = [
+            TimeSlice(m_start, m_start + Day(1), temporal_block(:block_a)),
+            TimeSlice(m_start, m_start + Week(1), temporal_block(:long_block)),
+            TimeSlice(m_start + Day(3), m_start + Day(4), temporal_block(:block_b))
+        ]
+        @testset for (obs, exp) in zip(obs_time_slices, exp_time_slices)
+            @test obs == exp
+        end
+        obs_hist_time_slices = history_time_slice(m)
+        exp_hist_time_slices = [
+            TimeSlice(m_start - Week(1), m_start, temporal_block(:long_block)),
+            TimeSlice(m_start - Day(1), m_start, temporal_block(:block_a)),
+            TimeSlice(m_start + Day(2), m_start + Day(3), temporal_block(:block_b))
+        ]
+        @testset for (obs, exp) in zip(obs_hist_time_slices, exp_hist_time_slices)
+            @test obs == exp
+        end
+    end
+end
+
 @testset "temporal structure" begin
     _test_representative_time_slice()
     _test_zero_resolution()
@@ -488,4 +531,5 @@ end
     _test_to_time_slice_with_rolling()
     _test_history()
     _test_master_temporal_structure()
+    _test_snapshots()
 end

--- a/test/run_spineopt_benders.jl
+++ b/test/run_spineopt_benders.jl
@@ -188,7 +188,7 @@ function _test_benders_storage()
         penalty = 100
         op_cost_no_inv = (fixuflow - dem) * penalty * (24 + look_ahead) # (20-10)*100*(24+3) = 27000
         op_cost_inv = 0
-        do_not_inv_cost = op_cost_no_inv - op_cost_inv # minimum cost at which investment is not profitable, 27000
+        do_not_inv_cost = op_cost_no_inv - op_cost_inv + 1 # minimum cost at which investment is not profitable, 27000
         do_inv_cost = do_not_inv_cost - 1  # maximum cost at which investment is profitable, 26999
         @testset for should_invest in (true, false)
             s_inv_cost = should_invest ? do_inv_cost : do_not_inv_cost

--- a/test/run_spineopt_benders.jl
+++ b/test/run_spineopt_benders.jl
@@ -188,7 +188,7 @@ function _test_benders_storage()
         penalty = 100
         op_cost_no_inv = (fixuflow - dem) * penalty * (24 + look_ahead) # (20-10)*100*(24+3) = 27000
         op_cost_inv = 0
-        do_not_inv_cost = op_cost_no_inv - op_cost_inv + 1 # minimum cost at which investment is not profitable, 27000
+        do_not_inv_cost = op_cost_no_inv - op_cost_inv # minimum cost at which investment is not profitable, 27000
         do_inv_cost = do_not_inv_cost - 1  # maximum cost at which investment is profitable, 26999
         @testset for should_invest in (true, false)
             s_inv_cost = should_invest ? do_inv_cost : do_not_inv_cost


### PR DESCRIPTION
Here we introduce the has_free_start boolean parameter for the temporal_block class, allowing us to setup a free start for operational variables in the middle of the optimisation.

The implementation relies on creating history time slices directly before the blocks with has_free_start = true. This should (if I'm not mistaken) take care of everything because when creating constraints, we already skip time slices marked as history. So effectively, variables will be free for those history time slices just before the block, and the block will thus have a free start. 

I have added a test that checks that has_free_start is correctly handled when creating the temporal structure. What I believe is missing is a test that checks that such temporal structure actually satisfies the requirement for the variables to have a free start in the blocks with has_free_start = true. But @datejada offered to help with that (thanks). To clarify, what the test needs to do is build the model and check that no constraints are created for the history time slices that belong to the history of a block with has_free_start = true. And that the 'dynamic' constraints at the beginning of the block actually use the time slices from that history.

Fixes #1238 

Note: In the code I use the term 'subwindow' to refer to a block with free start, but we don't need to communicate that to the user of course. Also, before merging we should document the new parameter and perhaps somebody else could help with that?

## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Unit tests have been added/updated accordingly
- [ ] improved [type stability](https://modernjuliaworkflows.org/optimizing/#type_stability) or, when outside the scope of the pull request, at least indicated where and how the code is not properly typed
- [ ] Code has been formatted according to SpineOpt's style
- [ ] Unit tests pass
