### PR TITLE
Fix units_started_up coefficient in unit flow ratio

### DIFF
--- a/src/constraints/constraint_ratio_unit_flow.jl
+++ b/src/constraints/constraint_ratio_unit_flow.jl
@@ -142,7 +142,6 @@ function _build_constraint_ratio_unit_flow(m::Model, u, ng1, ng2, s_path, t, rat
             * units_on_coeff(m; unit=u, node1=ng1, node2=ng2, stochastic_scenario=s, t=t)
             + start_flow_sign
             * _get_units_started_up(m, u, s, t1)
-            * min(duration(t1), duration(t))
             * unit_start_flow(m; unit=u, node1=ng1, node2=ng2, stochastic_scenario=s, t=t)
             for (u, s, t1) in unit_stochastic_time_indices(
                 m; unit=u, stochastic_scenario=s_path, t=t_overlaps_t(m; t=t)

--- a/src/variables/variable_unit_flow.jl
+++ b/src/variables/variable_unit_flow.jl
@@ -142,7 +142,9 @@ function add_variable_unit_flow!(m::Model)
                 (unit=u, stochastic_scenario=s, t=t) => _fix_units_on_coeff(m, u, n, n_ref, s, t, fix_ratio, direct)
             ),
             :units_started_up => Dict(
-                (unit=u, stochastic_scenario=s, t=t) => _signed_unit_start_flow(m, u, n, n_ref, s, t, fix_ratio, direct)
+                (unit=u, stochastic_scenario=s, t=t) => /(
+                    _signed_unit_start_flow(m, u, n, n_ref, s, t, fix_ratio, direct), duration(t)
+                )
             ),
         )
         for (u, n_ref, d_ref, n, d, fix_ratio, direct) in _related_flows(fix_ratio_d1_d2)


### PR DESCRIPTION
The unit_start_flow was being multiplied by the duration of the time slice, as if this flow was happening at every hour of the day for instance. But the correct interpretation should be that it flows only once regardless of the resolution at which the unit_flow variable is being tracked.

This also keeps consistency with the unit_pw_heat_rate constraint so the behaviour is unaltered compared to old models that used that constraint.

## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Unit tests have been added/updated accordingly
- [ ] improved [type stability](https://modernjuliaworkflows.org/optimizing/#type_stability) or, when outside the scope of the pull request, at least indicated where and how the code is not properly typed
- [ ] Code has been formatted according to SpineOpt's style
- [ ] Unit tests pass
