### PR TITLE
Has free start

### DIFF
--- a/examples/capacity_planning.json
+++ b/examples/capacity_planning.json
@@ -3608,6 +3608,13 @@
         ],
         [
             "temporal_block",
+            "has_free_start",
+            false,
+            "boolean_value_list",
+            "Whether the block requires a fresh start (own independent history)"
+        ],
+        [
+            "temporal_block",
             "is_active",
             true,
             "boolean_value_list",

--- a/examples/multi-year_investment_with_econ_discounting_consecutives.json
+++ b/examples/multi-year_investment_with_econ_discounting_consecutives.json
@@ -3431,6 +3431,13 @@
         ],
         [
             "temporal_block",
+            "has_free_start",
+            false,
+            "boolean_value_list",
+            "Whether the block requires a fresh start (own independent history)"
+        ],
+        [
+            "temporal_block",
             "is_active",
             true,
             "boolean_value_list",

--- a/examples/multi-year_investment_with_econ_discounting_milestones.json
+++ b/examples/multi-year_investment_with_econ_discounting_milestones.json
@@ -3503,6 +3503,13 @@
         ],
         [
             "temporal_block",
+            "has_free_start",
+            false,
+            "boolean_value_list",
+            "Whether the block requires a fresh start (own independent history)"
+        ],
+        [
+            "temporal_block",
             "is_active",
             true,
             "boolean_value_list",

--- a/examples/multi-year_investment_without_econ_discounting.json
+++ b/examples/multi-year_investment_without_econ_discounting.json
@@ -3424,6 +3424,13 @@
         ],
         [
             "temporal_block",
+            "has_free_start",
+            false,
+            "boolean_value_list",
+            "Whether the block requires a fresh start (own independent history)"
+        ],
+        [
+            "temporal_block",
             "is_active",
             true,
             "boolean_value_list",

--- a/examples/reserves.json
+++ b/examples/reserves.json
@@ -2152,6 +2152,13 @@
         ],
         [
             "temporal_block",
+            "has_free_start",
+            false,
+            "boolean_value_list",
+            "Whether the block requires a fresh start (own independent history)"
+        ],
+        [
+            "temporal_block",
             "is_active",
             true,
             "boolean_value_list",

--- a/examples/rolling_horizon.json
+++ b/examples/rolling_horizon.json
@@ -2152,6 +2152,13 @@
         ],
         [
             "temporal_block",
+            "has_free_start",
+            false,
+            "boolean_value_list",
+            "Whether the block requires a fresh start (own independent history)"
+        ],
+        [
+            "temporal_block",
             "is_active",
             true,
             "boolean_value_list",

--- a/examples/simple_system.json
+++ b/examples/simple_system.json
@@ -2152,6 +2152,13 @@
         ],
         [
             "temporal_block",
+            "has_free_start",
+            false,
+            "boolean_value_list",
+            "Whether the block requires a fresh start (own independent history)"
+        ],
+        [
+            "temporal_block",
             "is_active",
             true,
             "boolean_value_list",

--- a/examples/stochastic.json
+++ b/examples/stochastic.json
@@ -3438,6 +3438,13 @@
         ],
         [
             "temporal_block",
+            "has_free_start",
+            false,
+            "boolean_value_list",
+            "Whether the block requires a fresh start (own independent history)"
+        ],
+        [
+            "temporal_block",
             "is_active",
             true,
             "boolean_value_list",

--- a/examples/unit_commitment.json
+++ b/examples/unit_commitment.json
@@ -2152,6 +2152,13 @@
         ],
         [
             "temporal_block",
+            "has_free_start",
+            false,
+            "boolean_value_list",
+            "Whether the block requires a fresh start (own independent history)"
+        ],
+        [
+            "temporal_block",
             "is_active",
             true,
             "boolean_value_list",

--- a/src/constraints/constraint_cyclic_node_state.jl
+++ b/src/constraints/constraint_cyclic_node_state.jl
@@ -51,17 +51,30 @@ function _build_constraint_cyclic_node_state(m::Model, n, s_path, t_start, t_end
     )
 end
 
-function constraint_cyclic_node_state_indices(m::Model)
-    (
-        (node=n, stochastic_path=path, t_start=t_start, t_end=t_end, temporal_block=blk)
-        for (n, blk) in indices(cyclic_condition)
+@generator function constraint_cyclic_node_state_indices(m::Model)
+    for (n, blk) in indices(cyclic_condition)
         if cyclic_condition(node=n, temporal_block=blk)
-        for t_start in filter(
-            x -> blk in blocks(x), t_before_t(m; t_after=first(collect(time_slice(m; temporal_block=members(blk)))))
-        )
-        for t_end in last(collect(time_slice(m; temporal_block=members(blk))))
-        for path in active_stochastic_paths(m, node_state_indices(m; node=n, t=[t_start, t_end]))
-    )
+            for t_start in _t_start(m, blk)
+                for t_end in last(collect(time_slice(m; temporal_block=members(blk))))
+                    for path in active_stochastic_paths(m, node_state_indices(m; node=n, t=[t_start, t_end]))
+                        @yield (node=n, stochastic_path=path, t_start=t_start, t_end=t_end, temporal_block=blk)
+                    end
+                end
+            end
+        end
+    end
+end
+
+function _t_start(m, blk)
+    t_start = first(collect(time_slice(m; temporal_block=members(blk))))
+    t_before_start = filter(t_before_t(m; t_after=t_start)) do t
+        blk in blocks(t)
+    end
+    if isempty(t_before_start)
+        t_start
+    else
+        t_before_start
+    end
 end
 
 function constraint_cyclic_node_state_indices_filtered(

--- a/src/constraints/constraint_cyclic_node_state.jl
+++ b/src/constraints/constraint_cyclic_node_state.jl
@@ -51,18 +51,15 @@ function _build_constraint_cyclic_node_state(m::Model, n, s_path, t_start, t_end
     )
 end
 
-@generator function constraint_cyclic_node_state_indices(m::Model)
-    for (n, blk) in indices(cyclic_condition)
+function constraint_cyclic_node_state_indices(m::Model)
+    (
+        (node=n, stochastic_path=path, t_start=t_start, t_end=t_end, temporal_block=blk)
+        for (n, blk) in indices(cyclic_condition)
         if cyclic_condition(node=n, temporal_block=blk)
-            for t_start in _t_start(m, blk)
-                for t_end in last(collect(time_slice(m; temporal_block=members(blk))))
-                    for path in active_stochastic_paths(m, node_state_indices(m; node=n, t=[t_start, t_end]))
-                        @yield (node=n, stochastic_path=path, t_start=t_start, t_end=t_end, temporal_block=blk)
-                    end
-                end
-            end
-        end
-    end
+        for t_start in _t_start(m, blk)
+        for t_end in last(collect(time_slice(m; temporal_block=members(blk))))
+        for path in active_stochastic_paths(m, node_state_indices(m; node=n, t=[t_start, t_end]))
+    )
 end
 
 function _t_start(m, blk)

--- a/src/data_structure/temporal_structure.jl
+++ b/src/data_structure/temporal_structure.jl
@@ -682,7 +682,13 @@ function dynamic_time_indices(m, blk; t_before=anything, t_after=anything)
             m; t_before=t_before, t_after=time_slice(m; temporal_block=members(blk), t=t_after), _compact=false
         )
         if !isempty(intersect(members(blk), blocks(tb)))
+        && !_is_a_free_start(m, ta)
     )
+end
+
+function _is_a_free_start(m, t)
+    blocks_with_free_start = [blk for blk in blocks(t) if has_free_start(temporal_block=blk)]
+    any(t == first(time_slice(m; temporal_block=blk)) for blk in blocks_with_free_start)
 end
 
 """

--- a/src/util/misc.jl
+++ b/src/util/misc.jl
@@ -78,56 +78,6 @@ macro fetch(expr)
     esc(Expr(:(=), keys, values))
 end
 
-"""
-    @generator function(foo)
-        for x in 1:10
-            @yield x
-        end
-    end
-
-Create a Python-style generator from the given function that calls the @yield macro.
-"""
-macro generator(f)
-    if f.head != :function
-        error("please use @generator with a function")
-    end
-    signature, body = f.args
-    name, args... = signature.args
-    channel = gensym()
-    _expand_yield_macro!(body, channel)
-    producer = gensym()
-    producer_fn = quote
-        function $(producer)($channel)
-            $(body)
-        end
-    end
-    quote
-        function $(esc(name))($(esc.(args)...))  # TODO: Support keyword arguments
-            $(esc(producer_fn))
-            Channel($(esc(producer)))
-        end
-    end
-end
-
-macro yield(x)
-    x
-end
-
-function _expand_yield_macro!(expr::Expr, channel)
-    for (k, x) in enumerate(expr.args)
-        x isa Expr || continue
-        if x.head == :macrocall && x.args[1] == Symbol("@yield")
-            # TODO: make sure @yield is called correctly by checking x.args[2:end]
-            value = x.args[end]
-            expr.args[k] = quote
-                put!($channel, $value)
-            end
-        else
-            _expand_yield_macro!(x, channel)
-        end
-    end
-end
-
 struct ParameterFunction
     fn
 end

--- a/templates/spineopt_template.json
+++ b/templates/spineopt_template.json
@@ -280,6 +280,7 @@
         ["stage", "stage_scenario", null, null, "The scenario that this `stage` should run (EXPERIMENTAL)."],
         ["temporal_block", "block_end", null, null, "The end time for the `temporal_block`. Can be given either as a `DateTime` for a static end point, or as a `Duration` for an end point relative to the start of the current optimization."],
         ["temporal_block", "block_start", null, null, "The start time for the `temporal_block`. Can be given either as a `DateTime` for a static start point, or as a `Duration` for an start point relative to the start of the current optimization."],
+        ["temporal_block", "has_free_start", false, "boolean_value_list", "Whether the block requires a free start for variables associated to it"],
         ["temporal_block", "representative_period_index", null, null, "Index for the array of coefficients defined in `representative_periods_mapping`"],
         ["temporal_block", "representative_periods_mapping", null, null, "Map from date time to representative temporal block combination (either a single block's name, or an array of coefficients for each block that has a `representative_period_index`)"],
         ["temporal_block", "resolution", {"type": "duration", "data": "1h"}, null, "Temporal resolution of the `temporal_block`. Essentially, divides the period between `block_start` and `block_end` into `TimeSlices` with the input `resolution`."],

--- a/test/constraints/constraint_node.jl
+++ b/test/constraints/constraint_node.jl
@@ -1098,6 +1098,98 @@ function test_constraint_min_capacity_margin_penalty()
     end
 end
 
+function test_constraint_node_injection_free_start()
+    @testset "constraint_node_injection_free_start" begin
+        url_in = _test_constraint_node_setup()
+        objects = [["temporal_block","discontinuous_block"]]
+        object_parameter_values = [
+            ["temporal_block", "discontinuous_block", "has_free_start", true],
+            ["temporal_block", "discontinuous_block", "resolution", unparse_db_value(Hour(1))],
+            ["temporal_block", "discontinuous_block", "block_start", unparse_db_value(DateTime("2000-01-02T00:00:00"))],
+            ["temporal_block", "discontinuous_block", "block_end", unparse_db_value(DateTime("2000-01-02T02:00:00"))],
+            ["node", "node_b", "has_state", true],
+            ["node", "node_b", "node_state_cap", 100.0],
+            ["node", "node_b", "initial_node_state", 50.0],
+            ["temporal_block", "hourly", "block_end", unparse_db_value(DateTime("2000-01-01T02:00:00"))],
+            ["temporal_block", "two_hourly", "block_end", unparse_db_value(DateTime("2000-01-01T02:00:00"))],
+            ["temporal_block", "investments_hourly", "block_end", unparse_db_value(DateTime("2000-01-01T02:00:00"))],
+            ["model", "instance", "model_end", unparse_db_value(DateTime("2000-01-02T02:00:00"))],
+        ]
+        relationships = [
+            ["node__temporal_block", ["node_b", "discontinuous_block"]],
+        ]
+        SpineInterface.import_data(
+            url_in; objects=objects, object_parameter_values=object_parameter_values, relationships=relationships
+         )
+        m = run_spineopt(url_in; log_level=0, optimize=false)
+        # Check we don't have a node_injection constraint for the first time slice of the discontinuous block
+        con_n_inj = m.ext[:spineopt].constraints[:node_injection]
+        t_after = first(time_slice(m; temporal_block=temporal_block(:discontinuous_block)))
+        @test !(t_after in [x.t_after for x in keys(con_n_inj)])
+    end
+end
+
+function test_constraint_cyclic_node_state_free_start()
+    @testset "constraint_cyclic_node_state_free_start" begin
+        url_in = _test_constraint_node_setup()
+        objects = [["temporal_block","discontinuous_block"]]
+        node_capacity = Dict("node_b" => 120, "node_c" => 400)
+        storage_investment_tech_lifetime = Dict("type" => "duration", "data" => string(180, "m"))
+        object_parameter_values = [
+            ["temporal_block", "discontinuous_block", "has_free_start", true],
+            ["temporal_block", "discontinuous_block", "resolution", unparse_db_value(Hour(1))],
+            ["temporal_block", "discontinuous_block", "block_start", unparse_db_value(DateTime("2000-01-02T00:00:00"))],
+            ["temporal_block", "discontinuous_block", "block_end", unparse_db_value(DateTime("2000-01-02T02:00:00"))],
+            ["node", "node_b", "node_state_cap", node_capacity["node_b"]],
+            ["node", "node_c", "node_state_cap", node_capacity["node_c"]],
+            ["node", "node_b", "has_state", true],
+            ["node", "node_c", "has_state", true],
+            ["temporal_block", "hourly", "block_end", unparse_db_value(DateTime("2000-01-01T02:00:00"))],
+            ["temporal_block", "two_hourly", "block_end", unparse_db_value(DateTime("2000-01-01T02:00:00"))],
+            ["model", "instance", "model_end", unparse_db_value(DateTime("2000-01-02T02:00:00"))],
+            ["node", "node_c", "storage_investment_tech_lifetime", storage_investment_tech_lifetime],
+        ]
+        relationship_parameter_values = [
+            ["node__temporal_block", ["node_b", "discontinuous_block"], "cyclic_condition", true],
+            ["node__temporal_block", ["node_c", "discontinuous_block"], "cyclic_condition", true],
+        ]
+        relationships = [
+            ["node__temporal_block", ["node_b", "discontinuous_block"]],
+            ["node__temporal_block", ["node_c", "discontinuous_block"]],
+        ]
+        SpineInterface.import_data(
+            url_in; 
+            objects=objects, 
+            object_parameter_values=object_parameter_values, 
+            relationship_parameter_values=relationship_parameter_values,
+            relationships=relationships
+         )
+        m = run_spineopt(url_in; log_level=0, optimize=false)
+        var_node_state = m.ext[:spineopt].variables[:node_state]
+        constraint = m.ext[:spineopt].constraints[:cyclic_node_state]
+        @test length(constraint) == 2
+        return
+        scenario0 = stochastic_scenario(:parent)
+        scenario1 = stochastic_scenario(:child)
+        # Test for each node with cyclic condition on discontinuous_block
+        nodes_to_test = [node(:node_b), node(:node_c)]
+        @testset for n in nodes_to_test
+            blk = temporal_block(:discontinuous_block)
+            # For discontinuous block, we need to get the time slices properly
+            t0 = filter(x -> blk in blocks(x), t_before_t(m; t_after=first(time_slice(m; temporal_block=blk))))[1]
+            t1 = last(time_slice(m; temporal_block=blk))
+            var_n_st_key0 = (n, scenario0, t0)
+            var_n_st_key1 = (n, scenario1, t1)
+            con_key = (n, [scenario0, scenario1], t0, t1, blk)
+            var_n_st0 = var_node_state[var_n_st_key0...]
+            var_n_st1 = var_node_state[var_n_st_key1...]
+            expected_con = @build_constraint(var_n_st1 >= var_n_st0)
+            con = constraint[con_key...]
+            observed_con = constraint_object(con)
+            @test _is_constraint_equal(observed_con, expected_con)
+        end
+    end
+end
 
 @testset "node-based constraints" begin
     test_constraint_nodal_balance()
@@ -1121,4 +1213,6 @@ end
     test_constraint_storage_lifetime_mp()
     test_constraint_min_capacity_margin()
     test_constraint_min_capacity_margin_penalty()
+    test_constraint_node_injection_free_start()
+    test_constraint_cyclic_node_state_free_start()
 end


### PR DESCRIPTION
Another (hopefully better) approach to implementing temporal blocks with free start.

This supersedes https://github.com/spine-tools/SpineOpt.jl/pull/1245 (now closed).

Yesterday when I was putting my daughter to sleep I thought of a better way to implement this free start thing. Instead of creating middle histories with free variables and hoping that constraint indexing would do the trick, we could handle the has_free_start parameter directly in constraint indexing. This is easy because all the constraints that need successive time slices for their expression (node_injection, unit_state_transition, even unit_investment_transition) call the same function to obtain such time slices. So in this function, we can just check that the time slice we are going to deliver is not the first one of a block with free start. Simple. The result of this is no constraint is written for that time slice and the variables effectively have a free start at the begining of the block.

This is also cheaper because it doesn't introduce any new variables for the middle history periods, but especially is way less error prone than introducing those middle histories with possible overlapping of time slices and issues regarding the required history duration.

I gave it a try on a real model (provided by @aporrasc) and seems to do the trick.

I will give it one more review and then I can hand it to you @datejada to add more unit-tests?

**Edit**: I think this works well enough at the moment for you @datejada to take the next step.

## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Unit tests have been added/updated accordingly
- [ ] improved [type stability](https://modernjuliaworkflows.org/optimizing/#type_stability) or, when outside the scope of the pull request, at least indicated where and how the code is not properly typed
- [ ] Code has been formatted according to SpineOpt's style
- [ ] Unit tests pass
