### PR TITLE
Update 3rd party actions in GitHub actions

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -18,7 +18,7 @@ on:
       spinedb-api-ref-name:
         required: false
         type: string
-        default: 'master'
+        default: "master"
       coverage:
         required: false
         type: boolean
@@ -32,10 +32,10 @@ jobs:
     name: Julia ${{ inputs.julia-version }} - ${{ inputs.host-os }}
     runs-on: ${{ inputs.host-os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: ${{ inputs.repository }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python-version }}
       - uses: julia-actions/setup-julia@v2
@@ -43,16 +43,15 @@ jobs:
           version: ${{ inputs.julia-version }}
           arch: x64
       - name: Install spinedb_api
-        run:
-          julia ./.install_spinedb_api.jl ${{ inputs.spinedb-api-ref-name }}
+        run: julia ./.install_spinedb_api.jl ${{ inputs.spinedb-api-ref-name }}
         env:
           PYTHON: python
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-processcoverage@v1
         if: inputs.coverage && inputs.julia-version == '1' && inputs.host-os == 'ubuntu-latest'
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v6
         if: inputs.coverage && inputs.julia-version == '1' && inputs.host-os == 'ubuntu-latest'
         with:
-          file: lcov.info
+          files: lcov.info
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@v5
         with:
-          concurrent_skipping: 'same_content_newer'
+          concurrent_skipping: "same_content_newer"
   test:
     needs: check_duplicate_actions
     if: needs.check_duplicate_actions.outputs.should_skip != 'true'
@@ -30,7 +30,7 @@ jobs:
       matrix:
         version:
           - "1.10" # Replace "lts" with a specific Julia version
-          - "1"    # Latest Release of Julia v1.x
+          - "1" # Latest Release of Julia v1.x
         os:
           - ubuntu-latest
           # - macOS-latest
@@ -46,11 +46,11 @@ jobs:
           - os: windows-latest
             arch: x86
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
-          python-version: '3.11' 
-      - uses: julia-actions/setup-julia@v1
+          python-version: "3.11"
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
@@ -58,17 +58,16 @@ jobs:
           git config --global user.name Tester
           git config --global user.email te@st.er
       - name: Install spinedb_api
-        run:
-          julia ./.install_spinedb_api.jl
+        run: julia ./.install_spinedb_api.jl
         env:
           PYTHON: python
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-processcoverage@v1
         if: matrix.version == '1' && matrix.os == 'ubuntu-latest'
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v6
         with:
-          file: lcov.info
+          files: lcov.info
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   Documenter:
@@ -76,16 +75,15 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
-          python-version: '3.11' 
+          python-version: "3.11"
       - name: Install dependencies
         run: |
-          julia ./.install_spinedb_api.jl          
+          julia ./.install_spinedb_api.jl
           julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - uses: julia-actions/julia-docdeploy@latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
-


### PR DESCRIPTION
GitHub is deprecating the usage of Node.js 20 which will deprecate old actions as well.

No functional changes. No associated issue.

## Checklist before merging
~~- [ ] Documentation is up-to-date~~
~~- [ ] Unit tests have been added/updated accordingly~~
~~- [ ] improved [type stability](https://modernjuliaworkflows.org/optimizing/#type_stability) or, when outside the scope of the pull request, at least indicated where and how the code is not properly typed~~
~~- [ ] Code has been formatted according to SpineOpt's style~~
- [x] Unit tests pass
