### PR TITLE
Add checks for ramping parameters

### DIFF
--- a/src/data_structure/check_data_structure.jl
+++ b/src/data_structure/check_data_structure.jl
@@ -83,7 +83,7 @@ Check if at least one `node` is defined.
 """
 function check_node_object()
     _check(
-        !isempty(node()), "`node` object not found - you need at least one `node` to run a SpineOpt Operations Model",
+        !isempty(node()), "`node` object not found - you need at least one `node` to run a SpineOpt Operations Model"
     )
 end
 
@@ -184,7 +184,7 @@ function check_branching_before_rolling()
                 cond,
                 "invalid branching of `stochastic_structure` $ss before `model` $m rolls - ",
                 "please make sure that `stochastic_scenario_end` for `stochastic_scenario` $scen ",
-                "is larger than `roll_forward` for `model` $m",
+                "is larger than `roll_forward` for `model` $m"
             )
         end
     end
@@ -210,7 +210,7 @@ function check_operating_points()
     ]
     _check(
         isempty(error_indices),
-        "minimum operating point has to be between 0 and 1 for $(join(error_indices, ", ", " and ")) ",
+        "minimum operating point has to be between 0 and 1 for $(join(error_indices, ", ", " and ")) "
     )
 end
 
@@ -219,7 +219,7 @@ function check_ramp_parameters()
         # value between 0 and 1
         error_indices = [(u, n, d) for (u, n, d) in indices(param) if !(0 < param(unit=u, node=n, direction=d) <= 1)]
         _check(
-            isempty(error_indices), "$param has to be between 0 (excl) and 1 for $(join(error_indices, ", ", " and ")) ",
+            isempty(error_indices), "$param has to be between 0 (excl) and 1 for $(join(error_indices, ", ", " and ")) "
         )
     end
     # start_up_limit >= minimum_operating_point
@@ -227,12 +227,13 @@ function check_ramp_parameters()
     for param in (start_up_limit, shut_down_limit)
         # value greater than minimum_operating_point
         error_indices = [
-            (u, n, d) for (u, n, d) in intersect(indices(minimum_operating_point), indices(param)) if
-            minimum_operating_point(unit=u, node=n, direction=d) > param(unit=u, node=n, direction=d)
+            (u, n, d) 
+            for (u, n, d) in intersect(indices(minimum_operating_point), indices(param)) 
+            if minimum_operating_point(unit=u, node=n, direction=d) > param(unit=u, node=n, direction=d)
         ]
         _check(
             isempty(error_indices),
-            "$param must be greater or equal than minimum_operating_point for $(join(error_indices, ", ", " and ")) ",
+            "$param must be greater or equal than minimum_operating_point for $(join(error_indices, ", ", " and ")) "
         )
     end
     # start_up_limit <= minimum_operating_point + ramp_up_limit
@@ -250,7 +251,7 @@ function _check_startup_ramp_consistency()
     ]
     _check(
         isempty(error_indices),
-        "start_up_limit must be smaller or equal to minimum_operating_point + ramp_up_limit for $(join(error_indices, ", ", " and "))",
+        "start_up_limit must be smaller or equal to minimum_operating_point + ramp_up_limit for $(join(error_indices, ", ", " and "))"
     )
 end
 
@@ -263,6 +264,6 @@ function _check_shutdown_ramp_consistency()
     ]
     _check(
         isempty(error_indices),
-        "shut_down_limit must be smaller or equal to minimum_operating_point + ramp_down_limit for $(join(error_indices, ", ", " and "))",
+        "shut_down_limit must be smaller or equal to minimum_operating_point + ramp_down_limit for $(join(error_indices, ", ", " and "))"
     )
 end

--- a/src/data_structure/check_data_structure.jl
+++ b/src/data_structure/check_data_structure.jl
@@ -227,8 +227,8 @@ function check_ramp_parameters()
     for param in (start_up_limit, shut_down_limit)
         # value greater than minimum_operating_point
         error_indices = [
-            (u, n, d) 
-            for (u, n, d) in intersect(indices(minimum_operating_point), indices(param)) 
+            (u, n, d)
+            for (u, n, d) in intersect(indices(minimum_operating_point), indices(param))
             if minimum_operating_point(unit=u, node=n, direction=d) > param(unit=u, node=n, direction=d)
         ]
         _check(

--- a/src/data_structure/check_data_structure.jl
+++ b/src/data_structure/check_data_structure.jl
@@ -234,4 +234,40 @@ function check_ramp_parameters()
             "$param must be greater or equal than minimum_operating_point for $(join(error_indices, ", ", " and ")) "
         )
     end
+    # start_up_limit <= minimum_operating_point + ramp_up_limit
+    _check_startup_ramp_consistency()
+    # shut_down_limit <= minimum_operating_point + ramp_down_limit
+    _check_shutdown_ramp_consistency()
+end
+
+function _check_startup_ramp_consistency()
+    relevant_indices = union(indices(start_up_limit), indices(ramp_up_limit), indices(minimum_operating_point))
+    error_indices = [
+        (u, n, d)
+        for (u, n, d) in relevant_indices
+        if start_up_limit(unit=u, node=n, direction=d, _default=1)
+            > minimum_operating_point(unit=u, node=n, direction=d, _default=0)
+              + ramp_up_limit(unit=u, node=n, direction=d, _default=1)
+    ]
+    _check(
+        isempty(error_indices),
+        "start_up_limit must be <= minimum_operating_point + ramp_up_limit"
+        * " for $(join(error_indices, ", ", " and "))"
+    )
+end
+
+function _check_shutdown_ramp_consistency()
+    relevant_indices = union(indices(shut_down_limit), indices(ramp_down_limit), indices(minimum_operating_point))
+    error_indices = [
+        (u, n, d)
+        for (u, n, d) in relevant_indices
+        if shut_down_limit(unit=u, node=n, direction=d, _default=1)
+            > minimum_operating_point(unit=u, node=n, direction=d, _default=0)
+              + ramp_down_limit(unit=u, node=n, direction=d, _default=1)
+    ]
+    _check(
+        isempty(error_indices),
+        "shut_down_limit must be <= minimum_operating_point + ramp_down_limit"
+        * " for $(join(error_indices, ", ", " and "))"
+    )
 end

--- a/src/data_structure/check_data_structure.jl
+++ b/src/data_structure/check_data_structure.jl
@@ -83,7 +83,7 @@ Check if at least one `node` is defined.
 """
 function check_node_object()
     _check(
-        !isempty(node()), "`node` object not found - you need at least one `node` to run a SpineOpt Operations Model"
+        !isempty(node()), "`node` object not found - you need at least one `node` to run a SpineOpt Operations Model",
     )
 end
 
@@ -184,7 +184,7 @@ function check_branching_before_rolling()
                 cond,
                 "invalid branching of `stochastic_structure` $ss before `model` $m rolls - ",
                 "please make sure that `stochastic_scenario_end` for `stochastic_scenario` $scen ",
-                "is larger than `roll_forward` for `model` $m"
+                "is larger than `roll_forward` for `model` $m",
             )
         end
     end
@@ -210,7 +210,7 @@ function check_operating_points()
     ]
     _check(
         isempty(error_indices),
-        "minimum operating point has to be between 0 and 1 for $(join(error_indices, ", ", " and ")) "
+        "minimum operating point has to be between 0 and 1 for $(join(error_indices, ", ", " and ")) ",
     )
 end
 
@@ -219,19 +219,20 @@ function check_ramp_parameters()
         # value between 0 and 1
         error_indices = [(u, n, d) for (u, n, d) in indices(param) if !(0 < param(unit=u, node=n, direction=d) <= 1)]
         _check(
-            isempty(error_indices), "$param has to be between 0 (excl) and 1 for $(join(error_indices, ", ", " and ")) "
+            isempty(error_indices), "$param has to be between 0 (excl) and 1 for $(join(error_indices, ", ", " and ")) ",
         )
     end
+    # start_up_limit >= minimum_operating_point
+    # shut_down_limit >= minimum_operating_point
     for param in (start_up_limit, shut_down_limit)
         # value greater than minimum_operating_point
         error_indices = [
-            (u, n, d)
-            for (u, n, d) in intersect(indices(minimum_operating_point), indices(param))
-            if minimum_operating_point(unit=u, node=n, direction=d) > param(unit=u, node=n, direction=d)
+            (u, n, d) for (u, n, d) in intersect(indices(minimum_operating_point), indices(param)) if
+            minimum_operating_point(unit=u, node=n, direction=d) > param(unit=u, node=n, direction=d)
         ]
         _check(
             isempty(error_indices),
-            "$param must be greater or equal than minimum_operating_point for $(join(error_indices, ", ", " and ")) "
+            "$param must be greater or equal than minimum_operating_point for $(join(error_indices, ", ", " and ")) ",
         )
     end
     # start_up_limit <= minimum_operating_point + ramp_up_limit
@@ -243,31 +244,25 @@ end
 function _check_startup_ramp_consistency()
     relevant_indices = union(indices(start_up_limit), indices(ramp_up_limit), indices(minimum_operating_point))
     error_indices = [
-        (u, n, d)
-        for (u, n, d) in relevant_indices
-        if start_up_limit(unit=u, node=n, direction=d, _default=1)
-            > minimum_operating_point(unit=u, node=n, direction=d, _default=0)
-              + ramp_up_limit(unit=u, node=n, direction=d, _default=1)
+        (u, n, d) for (u, n, d) in relevant_indices 
+        if start_up_limit(unit=u, node=n, direction=d, _default=1) >
+        minimum_operating_point(unit=u, node=n, direction=d, _default=0) + ramp_up_limit(unit=u, node=n, direction=d, _default=1)
     ]
     _check(
         isempty(error_indices),
-        "start_up_limit must be <= minimum_operating_point + ramp_up_limit"
-        * " for $(join(error_indices, ", ", " and "))"
+        "start_up_limit must be smaller or equal to minimum_operating_point + ramp_up_limit for $(join(error_indices, ", ", " and "))",
     )
 end
 
 function _check_shutdown_ramp_consistency()
     relevant_indices = union(indices(shut_down_limit), indices(ramp_down_limit), indices(minimum_operating_point))
     error_indices = [
-        (u, n, d)
-        for (u, n, d) in relevant_indices
-        if shut_down_limit(unit=u, node=n, direction=d, _default=1)
-            > minimum_operating_point(unit=u, node=n, direction=d, _default=0)
-              + ramp_down_limit(unit=u, node=n, direction=d, _default=1)
+        (u, n, d) for (u, n, d) in relevant_indices 
+        if shut_down_limit(unit=u, node=n, direction=d, _default=1) >
+        minimum_operating_point(unit=u, node=n, direction=d, _default=0) + ramp_down_limit(unit=u, node=n, direction=d, _default=1)
     ]
     _check(
         isempty(error_indices),
-        "shut_down_limit must be <= minimum_operating_point + ramp_down_limit"
-        * " for $(join(error_indices, ", ", " and "))"
+        "shut_down_limit must be smaller or equal to minimum_operating_point + ramp_down_limit for $(join(error_indices, ", ", " and "))",
     )
 end


### PR DESCRIPTION
Fixes #1298 

- add to the existing check_data_structure(), this is after pre-processing, but before creating the actual problem.
- line 225-238 checks lower bound of start_up_limit and shut_down_limit, line 236-269 checks the upper bounds
- in case **any** of the parameters are not filled in, the default values will be provided in the check - this behavior is what happens during the constraint building. For example, if a user only gives ramp_up_limit or ramp_down_limit but **not** start_up_limit or shut_down_limit, default of 1 will be filled in to the start_up_limit or shut_down_limit. Then this check will error. 



## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Unit tests have been added/updated accordingly
- [x] improved [type stability](https://modernjuliaworkflows.org/optimizing/#type_stability) or, when outside the scope of the pull request, at least indicated where and how the code is not properly typed
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
