### PR TITLE
Bypass `convenience_functions.jl` regeneration if it fails.

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -16,8 +16,12 @@ srcfile = joinpath(pkgroot, "src", "convenience_functions.jl")
 # - if it is NOT located under the hashed `.julia/packages` depot folder.
 if isdir(joinpath(pkgroot, ".git")) || !occursin("/.julia/packages/", lowercase(pkgroot_unix))
 	@info "Generating convenience_functions.jl for dev package installation at $pkgroot"
-	open(srcfile, "w") do io
-		write_interface(io, template)
+	try
+		open(srcfile, "w") do io
+			write_interface(io, template)
+		end
+	catch
+		@warn "Failed to generate convenience_functions.jl! Likely due to missing permissions."
 	end
 else
 	@info "Skipping generation of convenience_functions.jl for non-dev package installation at $pkgroot"


### PR DESCRIPTION
Quick patch to avoid issues with JuliaRegistrator when registering a new version.

The `convenience_functions.jl` regenration while building SpineOpt was causing permission errors when trying to rewrite the file during the registration process. For now, I've bypassed this by simply handing the exception with a warning in the case where the file cannot be rewritten. Seems to work based on the registrator.
