### PR TITLE
Add run_spineopt model info into running logs

### DIFF
--- a/src/run_spineopt.jl
+++ b/src/run_spineopt.jl
@@ -161,9 +161,9 @@ function _run_spineopt(
     f(m)
     run_spineopt!(m, url_out; log_level, alternative, kwargs...)
     @log log_level 3 "\nSpineOpt model instance summary:"
-    log_level >= 3 && map(i -> print_active(m, i), [:variables, :objective_terms, :constraints])
+    log_level >= 3 && foreach(i -> print_active(m, i), [:variables, :objective_terms, :constraints])
     @log log_level 3 "\nActive model outputs not included in the report:"
-    log_level >= 3 && map(println, hidden_active_outputs(m))
+    log_level >= 3 && foreach(println, hidden_active_outputs(m))
     t_end = now()
     elapsed_time_string = _elapsed_time_string(t_start, t_end)
     @log log_level 1 "\nExecution complete. Started at $t_start, ended at $t_end, elapsed time: $elapsed_time_string"
@@ -706,8 +706,11 @@ end
 Active items of a field of an `SpineOptExt` instance.
 """
 function active_spineopt_ext_items(spineopt_ext::SpineOptExt, field::Symbol)::Vector{Symbol}
-    data = getproperty(spineopt_ext, field)
-    [key for key in keys(data) if !isnothing(data[key]) && !(isempty(data[key]) || isequal(data[key], (0, 0)))]
+    items = getproperty(spineopt_ext, field)
+    sort([
+        key for key in keys(items) 
+        if !isnothing(items[key]) && !isempty(items[key]) && !isequal(items[key], (0, 0))
+    ])
 end
 
 """
@@ -716,9 +719,7 @@ end
 Active model outputs that are not reported
 """
 function hidden_active_outputs(m::JuMP.Model)::Vector{Symbol}
-    model_values = m.ext[:spineopt].values
-    model_outputs = m.ext[:spineopt].outputs
-    hidden_values = setdiff(keys(model_values), keys(model_outputs)) |> collect
-    active_values = active_spineopt_ext_items(m.ext[:spineopt], :values)
-    return intersect(hidden_values, active_values) |> collect
+    spineopt_ext = m.ext[:spineopt]
+    hidden_outputs = setdiff(keys(spineopt_ext.values), keys(spineopt_ext.outputs))
+    return intersect(hidden_outputs, active_spineopt_ext_items(spineopt_ext, :values)) |> sort
 end

--- a/src/run_spineopt.jl
+++ b/src/run_spineopt.jl
@@ -721,5 +721,5 @@ Active model outputs that are not reported
 function hidden_active_outputs(m::JuMP.Model)::Vector{Symbol}
     spineopt_ext = m.ext[:spineopt]
     hidden_outputs = setdiff(keys(spineopt_ext.values), keys(spineopt_ext.outputs))
-    return intersect(hidden_outputs, active_spineopt_ext_items(spineopt_ext, :values)) |> sort
+    return intersect(hidden_outputs, active_spineopt_ext_items(spineopt_ext, :values)) |> collect |> sort
 end

--- a/src/run_spineopt.jl
+++ b/src/run_spineopt.jl
@@ -166,7 +166,7 @@ function _run_spineopt(
     log_level >= 3 && foreach(println, hidden_active_outputs(m))
     t_end = now()
     elapsed_time_string = _elapsed_time_string(t_start, t_end)
-    @log log_level 1 "Execution complete. Started at $t_start, ended at $t_end, elapsed time: $elapsed_time_string"
+    @log log_level 1 "\nExecution complete. Started at $t_start, ended at $t_end, elapsed time: $elapsed_time_string"
     if url_out !== nothing
         stat_keys = [
             :SpineOpt_version, :SpineOpt_git_hash, :SpineInterface_version, :SpineInterface_git_hash, :elapsed_time

--- a/test/run_spineopt.jl
+++ b/test/run_spineopt.jl
@@ -896,6 +896,96 @@ function _test_add_event_handler()
     end
 end
 
+function _test_active_spineopt_ext_items()
+    @testset "active_spineopt_ext_items" begin
+        url_in, url_out, _ = _test_run_spineopt_setup()
+        m = run_spineopt(url_in, url_out; log_level=0, optimize=false)
+        ext = m.ext[:spineopt]
+
+        @testset "returns Vector{Symbol}" begin
+            @test SpineOpt.active_spineopt_ext_items(ext, :variables) isa Vector{Symbol}
+        end
+
+        @testset "includes non-empty variable" begin
+            ext.variables[:_test_active] = Dict(:k => 1.0)
+            @test :_test_active ∈ SpineOpt.active_spineopt_ext_items(ext, :variables)
+        end
+
+        @testset "excludes empty variable" begin
+            ext.variables[:_test_empty] = Dict()
+            @test :_test_empty ∉ SpineOpt.active_spineopt_ext_items(ext, :variables)
+        end
+
+        @testset "excludes (0,0) objective term" begin
+            ext.objective_terms[:_test_zero] = (0, 0)
+            @test :_test_zero ∉ SpineOpt.active_spineopt_ext_items(ext, :objective_terms)
+        end
+
+        @testset "includes non-zero objective term" begin
+            ext.objective_terms[:_test_nonzero] = Dict(:k => 5.0)
+            @test :_test_nonzero ∈ SpineOpt.active_spineopt_ext_items(ext, :objective_terms)
+        end
+
+        @testset "excludes nothing output" begin
+            ext.outputs[:_test_nothing] = nothing
+            @test :_test_nothing ∉ SpineOpt.active_spineopt_ext_items(ext, :outputs)
+        end
+    end
+end
+
+function _test_print_active()
+    @testset "print_active" begin
+        url_in, url_out, _ = _test_run_spineopt_setup()
+        m = run_spineopt(url_in, url_out; log_level=0, optimize=false)
+
+        @testset "returns nothing" begin
+            @test SpineOpt.print_active(m, :variables) === nothing
+        end
+
+        @testset "does not throw on any model field" begin
+            for field in [:variables, :objective_terms, :constraints]
+                @test_nowarn SpineOpt.print_active(m, field)
+            end
+        end
+    end
+end
+
+function _test_hidden_active_outputs()
+    @testset "hidden_active_outputs" begin
+        url_in, url_out, _ = _test_run_spineopt_setup()
+        m = run_spineopt(url_in, url_out; log_level=0, optimize=false)
+        ext = m.ext[:spineopt]
+
+        @testset "returns Vector{Symbol}" begin
+            @test SpineOpt.hidden_active_outputs(m) isa Vector{Symbol}
+        end
+
+        @testset "includes active value not in outputs" begin
+            ext.values[:_test_hidden_active] = Dict(:k => 1.0)
+            @test :_test_hidden_active ∈ SpineOpt.hidden_active_outputs(m)
+        end
+
+        @testset "excludes active value that is in outputs" begin
+            ext.values[:_test_reported_active] = Dict(:k => 1.0)
+            ext.outputs[:_test_reported_active] = Dict()
+            @test :_test_reported_active ∉ SpineOpt.hidden_active_outputs(m)
+        end
+
+        @testset "excludes empty value not in outputs" begin
+            ext.values[:_test_hidden_empty] = Dict()
+            @test :_test_hidden_empty ∉ SpineOpt.hidden_active_outputs(m)
+        end
+
+        @testset "returns empty vector when all unreported values are inactive" begin
+            ext.values[:_test_all_inactive_a] = Dict()
+            ext.values[:_test_all_inactive_b] = Dict()
+            result = SpineOpt.hidden_active_outputs(m)
+            @test :_test_all_inactive_a ∉ result
+            @test :_test_all_inactive_b ∉ result
+        end
+    end
+end
+
 @testset "run_spineopt" begin
     _test_rolling()
     _test_rolling_with_updating_data()
@@ -919,4 +1009,7 @@ end
     _test_only_linear_model_has_duals()
     _test_report_relative_optimality_gap()
     _test_add_event_handler()
+    _test_active_spineopt_ext_items()
+    _test_print_active()
+    _test_hidden_active_outputs()
 end


### PR DESCRIPTION
Enable `run_spineopt()` to summarise active math model items (variable, constraint, objective term, including those that are hidden) at the end of its execution.

Fixes # (issue)

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] improved [type stability](https://modernjuliaworkflows.org/optimizing/#type_stability) or, when outside the scope of the pull request, at least indicated where and how the code is not properly typed
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
