### PR TITLE
Remove `@eval` from `generate_starting_point`

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -20,6 +20,13 @@ if isdir(joinpath(pkgroot, ".git")) || !occursin("/.julia/packages/", lowercase(
 		open(srcfile, "w") do io
 			write_interface(io, template)
 		end
+		# `starting_point` must use ObjectClass(:temporal_block) as its class dimension (not
+		# :starting_point) so that parameter lookups like `has_free_start(temporal_block=blk)` correctly resolve it.
+		# The template format cannot express this, so we append it manually.
+		open(srcfile, "a") do io
+			write(io, "\n# NOTE: manually appended — see deps/build.jl for explanation.\n")
+			write(io, "const starting_point = ObjectClass(:temporal_block)\nexport starting_point\n")
+		end
 	catch
 		@warn "Failed to generate convenience_functions.jl! Likely due to missing permissions."
 	end

--- a/src/convenience_functions.jl
+++ b/src/convenience_functions.jl
@@ -17,9 +17,7 @@ const stage = ObjectClass(:stage)
 const stochastic_scenario = ObjectClass(:stochastic_scenario)
 const stochastic_structure = ObjectClass(:stochastic_structure)
 const temporal_block = ObjectClass(:temporal_block)
-# NOTE: `starting_point` uses `:temporal_block` as its dimension (not `:starting_point`) and is
-# manually maintained here — the auto-generation via `deps/build.jl` cannot express this.
-const starting_point = ObjectClass(:temporal_block)
+const starting_point = ObjectClass(:starting_point)
 const unit = ObjectClass(:unit)
 const user_constraint = ObjectClass(:user_constraint)
 ## Relationship classes

--- a/src/convenience_functions.jl
+++ b/src/convenience_functions.jl
@@ -17,7 +17,7 @@ const stage = ObjectClass(:stage)
 const stochastic_scenario = ObjectClass(:stochastic_scenario)
 const stochastic_structure = ObjectClass(:stochastic_structure)
 const temporal_block = ObjectClass(:temporal_block)
-const starting_point = ObjectClass(:starting_point)
+const starting_point = ObjectClass(:temporal_block)
 const unit = ObjectClass(:unit)
 const user_constraint = ObjectClass(:user_constraint)
 ## Relationship classes

--- a/src/convenience_functions.jl
+++ b/src/convenience_functions.jl
@@ -17,6 +17,9 @@ const stage = ObjectClass(:stage)
 const stochastic_scenario = ObjectClass(:stochastic_scenario)
 const stochastic_structure = ObjectClass(:stochastic_structure)
 const temporal_block = ObjectClass(:temporal_block)
+# NOTE: `starting_point` uses `:temporal_block` as its dimension (not `:starting_point`) and is
+# manually maintained here — the auto-generation via `deps/build.jl` cannot express this.
+const starting_point = ObjectClass(:temporal_block)
 const unit = ObjectClass(:unit)
 const user_constraint = ObjectClass(:user_constraint)
 ## Relationship classes
@@ -398,6 +401,7 @@ export stage
 export stochastic_scenario
 export stochastic_structure
 export temporal_block
+export starting_point
 export unit
 export user_constraint
 ## Relationship classes

--- a/src/data_structure/preprocess_data_structure.jl
+++ b/src/data_structure/preprocess_data_structure.jl
@@ -871,28 +871,24 @@ function generate_starting_point()
     block_starting_point_relationships = [
         (blk, Object(string(blk.name, "_starting_point"), :temporal_block)) for blk in representative_blocks
     ]
-    starting_point_objects = last.(block_starting_point_relationships)
-    for obj in starting_point_objects
+    sp_objects = last.(block_starting_point_relationships)
+    for obj in sp_objects
         push!(obj.members, obj)
     end
-    starting_point_values = Dict(
-        obj => Dict(:has_free_start => parameter_value(false)) for obj in starting_point_objects
+    sp_values = Dict(
+        obj => Dict(:has_free_start => parameter_value(false)) for obj in sp_objects
     )
-    starting_point = ObjectClass(:temporal_block, starting_point_objects, starting_point_values)
+    merge!(starting_point.env_dict, ObjectClass(:temporal_block, sp_objects, sp_values).env_dict)
     add_relationships!( # TODO: Tasku: I think this might add `starting_point` objects into the `temporal_block` class, thus nullifying their "separation".
         node__temporal_block,
         [
-            (n, starting_point)
-            for (blk, starting_point) in block_starting_point_relationships
+            (n, sp_obj)
+            for (blk, sp_obj) in block_starting_point_relationships
             for n in node__temporal_block(temporal_block=[blk; groups(blk)])
         ]
     )
     push_class!(has_free_start, starting_point)
     add_relationships!(block__starting_point, block_starting_point_relationships)
-    @eval begin
-        starting_point = $starting_point
-        export starting_point
-    end
 end
 
 function generate_is_representative()

--- a/src/data_structure/preprocess_data_structure.jl
+++ b/src/data_structure/preprocess_data_structure.jl
@@ -871,19 +871,19 @@ function generate_starting_point()
     block_starting_point_relationships = [
         (blk, Object(string(blk.name, "_starting_point"), :temporal_block)) for blk in representative_blocks
     ]
-    sp_objects = last.(block_starting_point_relationships)
-    for obj in sp_objects
+    starting_point_objects = last.(block_starting_point_relationships)
+    for obj in starting_point_objects
         push!(obj.members, obj)
     end
-    sp_values = Dict(
-        obj => Dict(:has_free_start => parameter_value(false)) for obj in sp_objects
+    starting_point_values = Dict(
+        obj => Dict(:has_free_start => parameter_value(false)) for obj in starting_point_objects
     )
-    merge!(starting_point.env_dict, ObjectClass(:temporal_block, sp_objects, sp_values).env_dict)
+    merge!(starting_point.env_dict, ObjectClass(:temporal_block, starting_point_objects, starting_point_values).env_dict)
     add_relationships!( # TODO: Tasku: I think this might add `starting_point` objects into the `temporal_block` class, thus nullifying their "separation".
         node__temporal_block,
         [
-            (n, sp_obj)
-            for (blk, sp_obj) in block_starting_point_relationships
+            (n, starting_point)
+            for (blk, starting_point) in block_starting_point_relationships
             for n in node__temporal_block(temporal_block=[blk; groups(blk)])
         ]
     )

--- a/templates/preprocessing_template.json
+++ b/templates/preprocessing_template.json
@@ -4,7 +4,8 @@
         ["mga_iteration"],
         ["node_with_slack_penalty"],
         ["node_with_min_capacity_margin_penalty"],
-        ["benders_iteration"]
+        ["benders_iteration"],
+        ["starting_point"]
     ],
     "relationship_classes": [
         ["block__starting_point", ["temporal_block", "temporal_block"]],

--- a/templates/preprocessing_template.json
+++ b/templates/preprocessing_template.json
@@ -4,8 +4,7 @@
         ["mga_iteration"],
         ["node_with_slack_penalty"],
         ["node_with_min_capacity_margin_penalty"],
-        ["benders_iteration"],
-        ["starting_point"]
+        ["benders_iteration"]
     ],
     "relationship_classes": [
         ["block__starting_point", ["temporal_block", "temporal_block"]],


### PR DESCRIPTION
## Problem

`generate_starting_point()` in preprocess_data_structure.jl dynamically built an `ObjectClass` at runtime and exported it to the module scope using `@eval`:

```julia
starting_point = ObjectClass(:temporal_block, starting_point_objects, starting_point_values)
# ...
@eval begin
    starting_point = $starting_point
    export starting_point
end
```

This was the remaining `@eval` usage in the data structure preprocessing code, inconsistent with how all other classes are declared as static `const` module-level symbols populated at runtime.

## Solution

The approach follows the same pattern used by `benders_iteration` and `is_representative`: declare the symbol as a `const` upfront, then populate it at runtime using SpineInterface.

**Key insight**: `starting_point` must be declared as `ObjectClass(:temporal_block)` — not `ObjectClass(:starting_point)` — because SpineInterface matches parameter lookups like `has_free_start(temporal_block=blk)` against the class's `.name` field. This means the template auto-generation (which would produce `ObjectClass(:starting_point)`) cannot express this correctly.

## Changes

- **convenience_functions.jl**: Added `const starting_point = ObjectClass(:temporal_block)` and `export starting_point` as a manually-maintained declaration.

- **build.jl**: After `write_interface` regenerates convenience_functions.jl from the template (which happens in CI because .git is present), a second append step writes the `starting_point` declaration. This ensures CI always gets the correct `ObjectClass(:temporal_block)`.

- **preprocess_data_structure.jl**: Replaced the local `ObjectClass(...)` creation and `@eval` block with `merge!(starting_point.env_dict, ObjectClass(:temporal_block, sp_objects, sp_values).env_dict)`, which populates the module-level constant's active-environment entry.


## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Unit tests have been added/updated accordingly
- [ ] improved [type stability](https://modernjuliaworkflows.org/optimizing/#type_stability) or, when outside the scope of the pull request, at least indicated where and how the code is not properly typed
- [ ] Code has been formatted according to SpineOpt's style
- [ ] Unit tests pass
