### PR TITLE
Implement #1301

### DIFF
--- a/docs/src/concept_reference/online_variable_type.md
+++ b/docs/src/concept_reference/online_variable_type.md
@@ -5,6 +5,8 @@ If `binary`, then the commitment is modelled as an online/offline decision (clas
 
 If `integer`, then the commitment is modelled as the number of units that are online (clustered unit commitment). 
 
-If `linear`, then the commitment is modelled as the number of units that are online, but here it is also possible to activate 'fractions' of a unit. This should reduce computational burden compared to `integer`.
+If `linear`, then the commitment is modelled as the number of units that are online, but here it is also possible to activate 'fractions' of a unit.
+This should reduce computational burden compared to `integer`.
+Note that `linear` is a special case for which online variables are omitted if they are deemed unnecessary by the preprocessing.
 
 If `none`, then the committment is not modelled at all and the unit is assumed to be always online. This reduces the computational burden the most.

--- a/src/constraints/constraint_common.jl
+++ b/src/constraints/constraint_common.jl
@@ -45,8 +45,8 @@ function t_lowest_resolution_path(m, indices, extra_indices...)
     scens_by_t = t_lowest_resolution_sets!(m, _scens_by_t(indices))
     extra_scens_by_t = _scens_by_t(Iterators.flatten(extra_indices))
     for (t, scens) in scens_by_t
-        for t_long in t_in_t(m; t_short=t)
-            union!(scens, get(extra_scens_by_t, t_long, ()))
+        for t1 in t_overlaps_t(m; t=t)
+            union!(scens, get(extra_scens_by_t, t1, ()))
         end
     end
     ((t, path) for (t, scens) in scens_by_t for path in active_stochastic_paths(m, scens))

--- a/src/constraints/constraint_minimum_operating_point.jl
+++ b/src/constraints/constraint_minimum_operating_point.jl
@@ -124,7 +124,7 @@ function constraint_minimum_operating_point_indices(m::Model)
         for (u, ng, d) in indices(minimum_operating_point)
         if minimum_operating_point(; unit=u, node=ng, direction=d) != 0
         for (t, path) in t_lowest_resolution_path(
-            m, unit_flow_indices(m; unit=u, node=ng, direction=d), units_on_indices(m; unit=u)
+            m, unit_flow_indices(m; unit=u, node=ng, direction=d), _get_units_on_indices(m, u)
         )
     )
 end

--- a/src/constraints/constraint_operating_point_bounds.jl
+++ b/src/constraints/constraint_operating_point_bounds.jl
@@ -67,7 +67,7 @@ function constraint_operating_point_bounds_indices(m::Model)
         # NOTE: a stochastic_path is an array consisting of stochastic scenarios, e.g. [s1, s2]
         for (u, ng, d, i, _s, _t) in unit_flow_op_active_indices(m)
         for (t, path) in t_lowest_resolution_path(
-            m, unit_flow_op_indices(m; unit=u, node=ng, direction=d, i=i), units_on_indices(m; unit=u)
+            m, unit_flow_op_indices(m; unit=u, node=ng, direction=d, i=i), _get_units_on_indices(m, u)
         )
     )
 end

--- a/src/constraints/constraint_ratio_unit_flow.jl
+++ b/src/constraints/constraint_ratio_unit_flow.jl
@@ -208,7 +208,7 @@ function constraint_ratio_unit_flow_indices(m::Model, ratio)
             unit_flow_indices(m; unit=u2, node=[n1, n2]), # What is this doing?
             unit_flow_indices(m; unit=u1, node=n1, direction=d1),
             unit_flow_indices(m; unit=u2, node=n2, direction=d2),
-            units_on_indices(m; unit=u2),
+            _get_units_on_indices(m, u2),
         )
     )
 end

--- a/src/constraints/constraint_unit_flow_capacity.jl
+++ b/src/constraints/constraint_unit_flow_capacity.jl
@@ -212,7 +212,7 @@ function constraint_unit_flow_capacity_tight_compact_indices(m::Model)
             m,
             Iterators.flatten(
                 (
-                    units_on_indices(m; unit=u, t=[t_overlaps_t(m; t=t); t_next]),
+                    _get_units_on_indices(m, u; t=[t_overlaps_t(m; t=t); t_next]),
                     unit_flow_indices(m; unit=u, node=ng, direction=d, t=t_overlaps_t(m; t=t)),
                     _switch(
                         d; from_node=nonspin_units_started_up_indices, to_node=nonspin_units_shut_down_indices
@@ -279,7 +279,7 @@ function constraint_unit_flow_capacity_indices(m::Model)
     (
         (unit=u, node=ng, direction=d, stochastic_path=path, t=t)
         for (u, ng, d) in indices(capacity_per_unit)
-        if has_online_variable(unit=u) || members(ng) != [ng]
+        if has_online_variable(unit=u) || is_candidate(unit=u) || members(ng) != [ng]
         for t in t_highest_resolution(
             m,
             Iterators.flatten(
@@ -290,7 +290,7 @@ function constraint_unit_flow_capacity_indices(m::Model)
             m,
             Iterators.flatten(
                 (
-                    units_on_indices(m; unit=u, t=t_overlaps_t(m; t=t)),
+                    _get_units_on_indices(m, u; t=t_overlaps_t(m; t=t)),
                     unit_flow_indices(m; unit=u, node=ng, direction=d, t=t_overlaps_t(m; t=t)),
                 )
             )

--- a/src/constraints/constraint_units_available.jl
+++ b/src/constraints/constraint_units_available.jl
@@ -60,9 +60,9 @@ function _build_constraint_units_available(m, u, s, t)
         # Change the default `existing_units` so that it is zero when candidate units are present
         # and otherwise 1.
         + existing_units(m; unit=u, stochastic_scenario=s, t=t, _default=_default_nb_of_units(u))
-        - ifelse(
+        - ifelse( # Uses `out_of_service_count_fix` when there's no variable for it to fix?
             !has_out_of_service_variable(unit=u), 
-            out_of_service_count_fix(m; unit=u, stochastic_scenario=s, t=t, _default=0), 
+            out_of_service_count_fix(m; unit=u, stochastic_scenario=s, t=t, _default=0), # Why is the m here in `(m;...)` ?
             0
         )
     )

--- a/src/data_structure/preprocess_data_structure.jl
+++ b/src/data_structure/preprocess_data_structure.jl
@@ -779,11 +779,11 @@ function generate_unit_commitment_parameters()
     starts = [model_start(model=m) for m in models]
     instance = models[argmin(starts)]
     dur_unit = _model_duration_unit(instance)
-    dur_value = parameter_value(dur_unit(1))
+    dur_value = parameter_value(dur_unit(1)) # Tasku: I'm guessing this is to avoid simulateous startups and shutdowns?
 
-    for u in indices(online_variable_type)
+    for u in unit() # Tasku: `indices(online_variable_type)` is pointless overhead when there's a default value.
         unit_var_type = online_variable_type(unit=u)
-        if unit_var_type in (:binary, :integer)
+        if unit_var_type in (:binary, :integer) # Tasku: `:linear` not included? Online variables seem to be omitted if possible?
             min_up = min_up_time(unit=u)
             min_down = min_down_time(unit=u)
             params_to_add = Dict()
@@ -798,6 +798,7 @@ function generate_unit_commitment_parameters()
             end
         end
     end
+    # Tasku: These seem to deduce when startup/shutdown/outage/online variables are needed in the formulation.
     unit_with_switched_variable_set = unique(
         Iterators.flatten((
             indices(min_up_time),
@@ -836,11 +837,11 @@ function generate_unit_commitment_parameters()
             (x.unit for x in indices(ramp_limits_down)),
             (u for (st, u) in stage__output__unit(output=output(:units_on))),
             !isempty(stage__output(output=output(:units_on))) ? unit() : (),
-            (u for u in unit() if online_variable_type(unit=u) in (:binary, :integer)), # TODO: Shouldn't this permit `linear` as well?
+            (u for u in unit() if online_variable_type(unit=u) in (:binary, :integer)), # Tasku: Again, `:linear` is omitted if possible?
         )),
     )
-    unit_without_online_variable_iter = (u for u in unit() if online_variable_type(unit=u) == :none)
-    unit_without_out_of_service_variable_iter = (u for u in unit() if outage_variable_type(unit=u) == :none)
+    unit_without_online_variable_iter = unit(online_variable_type=:none)
+    unit_without_out_of_service_variable_iter = unit(outage_variable_type=:none)
     setdiff!(unit_with_switched_variable_set, unit_without_online_variable_iter)
     setdiff!(unit_with_out_of_service_variable_set, unit_without_out_of_service_variable_iter)
     setdiff!(unit_with_online_variable_set, unit_without_online_variable_iter)

--- a/src/variables/variable_units_invested_available.jl
+++ b/src/variables/variable_units_invested_available.jl
@@ -73,3 +73,13 @@ function add_variable_units_invested_available!(m::Model)
         required_history_period=maximum_parameter_value(lifetime_technical),
     )
 end
+
+"""
+    _get_units_invested_available(m, u, s, t)
+
+Safe get `units_invested_available` variable for the given indices,
+replaced with 0 in cases where the investment variable doesn't exist.
+"""
+function _get_units_invested_available(m, u, s, t)
+    get(m.ext[:spineopt].variables[:units_invested_available], (u, s, t), 0)
+end

--- a/src/variables/variable_units_invested_available.jl
+++ b/src/variables/variable_units_invested_available.jl
@@ -79,6 +79,9 @@ end
 
 Safe get `units_invested_available` variable for the given indices,
 replaced with 0 in cases where the investment variable doesn't exist.
+
+Intended to be used in situations where `units_invested_available` is required
+but one cannot ensure its existance.
 """
 function _get_units_invested_available(m, u, s, t)
     get(m.ext[:spineopt].variables[:units_invested_available], (u, s, t), 0)

--- a/src/variables/variable_units_on.jl
+++ b/src/variables/variable_units_on.jl
@@ -108,12 +108,18 @@ function add_variable_units_on!(m::Model)
     )
 end
 
+"""
+    _get_units_on(m, u, s, t)
+
+Safe get `units_on` variable for the given indices,
+replaced with `existing_units` plus [`_get_units_invested_available`](@ref)
+if `units_on` doesn't exist.
+"""
 function _get_units_on(m, u, s, t)
     get(m.ext[:spineopt].variables[:units_on], (u, s, t)) do
-        existing_units(unit=u, stochastic_scenario=s, t=t, _default=_default_nb_of_units(u))
+        (
+            existing_units(unit=u, stochastic_scenario=s, t=t, _default=_default_nb_of_units(u))
+            + _get_units_invested_available(m, u, s, t)
+        )
     end
-end
-
-function _get_units_started_up(m, u, s, t)
-    get(m.ext[:spineopt].variables[:units_started_up], (u, s, t), 0)
 end

--- a/src/variables/variable_units_on.jl
+++ b/src/variables/variable_units_on.jl
@@ -114,12 +114,34 @@ end
 Safe get `units_on` variable for the given indices,
 replaced with `existing_units` plus [`_get_units_invested_available`](@ref)
 if `units_on` doesn't exist.
+
+Intended to be used in situations where either `units_on` or its proxy is required,
+e.g. minimum load and ramping constraints.
+Currently, this doesn't handle complex time and stochastic structures.
+Defining identical structures for `units_on` and investments
+should hopefully bypass most issues.
 """
 function _get_units_on(m, u, s, t)
     get(m.ext[:spineopt].variables[:units_on], (u, s, t)) do
         (
             existing_units(unit=u, stochastic_scenario=s, t=t, _default=_default_nb_of_units(u))
             + _get_units_invested_available(m, u, s, t)
+            - _get_units_out_of_service(m, u, s, t)
         )
     end
+end
+
+"""
+    _get_units_on_indices(m::Model, unit::Object; kwargs...)
+
+Indexing selector for investments without online variables.
+See [`_get_units_on`](@ref).
+"""
+function _get_units_on_indices(m::Model, unit::Object; kwargs...)
+    inds = (unit=unit, kwargs...)
+    return (
+        online_variable_type(unit=unit) == :none && is_candidate(unit=unit) ?
+        units_invested_available_indices(m; inds...) :
+        units_on_indices(m; inds...)
+    )
 end

--- a/src/variables/variable_units_out_of_service.jl
+++ b/src/variables/variable_units_out_of_service.jl
@@ -71,6 +71,18 @@ function add_variable_units_out_of_service!(m::Model)
     )
 end
 
+"""
+    _get_units_out_of_service(m, u, s, t)
+
+Safe get `units_out_of_service` for the given indices,
+replaced by `out_of_service_count_fix` (default 0) when out-of-service
+variables don't exist.
+
+Intended to be used in situations where `units_out_of_service` is required,
+but one cannot ensure its existence.
+"""
 function _get_units_out_of_service(m, u, s, t)
-    get(m.ext[:spineopt].variables[:units_out_of_service], (u, s, t), 0)
+    get(m.ext[:spineopt].variables[:units_out_of_service], (u, s, t)) do 
+        out_of_service_count_fix(unit=u, stochastic_scenario=s, t=t, _default=0)
+    end
 end

--- a/src/variables/variable_units_started_up.jl
+++ b/src/variables/variable_units_started_up.jl
@@ -34,3 +34,13 @@ function add_variable_units_started_up!(m::Model)
         required_history_period=maximum_parameter_value(min_up_time),
     )
 end
+
+"""
+    _get_units_started_up(m, u, s, t)
+
+Safe get `units_started_up` variable for the given indices,
+replaced with 0 in case the variable doesn't exist.
+"""
+function _get_units_started_up(m, u, s, t)
+    get(m.ext[:spineopt].variables[:units_started_up], (u, s, t), 0)
+end

--- a/test/constraints/constraint_unit.jl
+++ b/test/constraints/constraint_unit.jl
@@ -144,15 +144,16 @@ function test_constraint_units_available()
         @test length(constraint) == 2
         scenarios = (stochastic_scenario(:parent), stochastic_scenario(:child))
         time_slices = time_slice(m; temporal_block=temporal_block(:hourly))
+        u = unit(:unit_ab)
         @testset for (s, t) in zip(scenarios, time_slices)
-            key = (unit(:unit_ab), s, t)
+            key = (u, s, t)
             var_u_on = var_units_on[key...]
             var_u_inv_av = var_units_invested_available[key...]
             expected_con = @build_constraint(var_u_on <= existing_units + var_u_inv_av)
-            con_key = (unit(:unit_ab), s, t)
-            con = constraint[con_key...]
+            con = constraint[key...]
             observed_con = constraint_object(con)
             @test _is_constraint_equal(observed_con, expected_con)
+            @test SpineOpt._get_units_out_of_service(m, key...) == 0
         end
     end
 end
@@ -182,15 +183,17 @@ function test_constraint_units_available_units_unavailable()
         @test length(constraint) == 2
         scenarios = (stochastic_scenario(:parent), stochastic_scenario(:child))
         time_slices = time_slice(m; temporal_block=temporal_block(:hourly))
+        u = unit(:unit_ab)
         @testset for (s, t) in zip(scenarios, time_slices)
-            key = (unit(:unit_ab), s, t)
+            key = (u, s, t)
             var_u_on = var_units_on[key...]
             var_u_inv_av = var_units_invested_available[key...]
             expected_con = @build_constraint(var_u_on <= existing_units + var_u_inv_av - out_of_service_count_fix)
-            con_key = (unit(:unit_ab), s, t)
+            con_key = (u, s, t)
             con = constraint[con_key...]
             observed_con = constraint_object(con)
             @test _is_constraint_equal(observed_con, expected_con)
+            @test SpineOpt._get_units_out_of_service(m, key...) == out_of_service_count_fix
         end
     end
     @testset "constraint_units_available_units_unavailable_default" begin
@@ -227,6 +230,7 @@ function test_constraint_units_available_units_unavailable()
             con = constraint[con_key...]
             observed_con = constraint_object(con)
             @test _is_constraint_equal(observed_con, expected_con)
+            @test SpineOpt._get_units_out_of_service(m, key...) == out_of_service_count_fix
         end
     end
     # Add a test for a unit with units_out_of_service variable
@@ -528,6 +532,81 @@ function test_constraint_minimum_operating_point()
                 observed_con = constraint_object(constraint[con_key])
                 @test _is_constraint_equal(observed_con, expected_con) 
             end
+        end
+    end
+    @testset "constraint_minimum_operating_point_online_variable_type_none" begin
+        uc = 100
+        mop = 0.25
+        ooscf = 1
+        eu = 2
+        icmc = 3 
+        relationship_parameter_values = [
+            ["node__to_unit", ["node_a", "unit_ab"], "capacity_per_unit", uc],
+            ["node__to_unit", ["node_a", "unit_ab"], "minimum_operating_point", mop],
+            ["unit__to_node", ["unit_ab", "node_b"], "capacity_per_unit", uc],
+            ["unit__to_node", ["unit_ab", "node_b"], "minimum_operating_point", mop],
+        ]
+        relationships = [
+            # Investment structure needs to match online structure in this case.
+            ["unit__investment_temporal_block", ["unit_ab", "hourly"]],
+            ["unit__investment_stochastic_structure", ["unit_ab", "stochastic"]],
+        ]
+        object_parameter_values = [
+            ["unit", "unit_ab", "existing_units", eu],
+            ["unit", "unit_ab", "investment_count_max_cumulative", icmc],
+            ["unit", "unit_ab", "online_variable_type", "none"],
+            ["unit", "unit_ab", "out_of_service_count_fix", ooscf],
+        ]
+        url_in = _test_constraint_unit_setup()
+        SpineInterface.import_data(
+            url_in;
+            relationships=relationships,
+            object_parameter_values=object_parameter_values,
+            relationship_parameter_values=relationship_parameter_values,
+        )
+        m = run_spineopt(url_in; log_level=0, optimize=false)
+        var_unit_flow = m.ext[:spineopt].variables[:unit_flow]
+        var_units_invested_available = m.ext[:spineopt].variables[:units_invested_available]
+        active_vars = (:unit_flow, :units_mothballed, :node_injection, :units_invested, :units_invested_available)
+        for (k,v) in m.ext[:spineopt].variables
+            @test in(k, active_vars) ? !isempty(v) : isempty(v)
+        end
+        active_cons = (:minimum_operating_point, :unit_flow_capacity, :nodal_balance, :node_injection, :units_invested_transition, :units_invested_available)
+        for (k,v) in m.ext[:spineopt].constraints
+            @test in(k, active_cons) ? !isempty(v) : isempty(v)
+        end
+        constraint = m.ext[:spineopt].constraints[:minimum_operating_point]
+        s_child = stochastic_scenario(:child)
+        s_parent = stochastic_scenario(:parent)
+        t1h1, t1h2 = time_slice(m; temporal_block=temporal_block(:hourly))
+        t2h = only(time_slice(m; temporal_block=temporal_block(:two_hourly)))
+        for (key, con) in constraint
+            (u, n, d, s_path, t) = key
+            @test u.name == :unit_ab
+            @test (n.name, d.name) in ((:node_a, :from_node), (:node_b, :to_node))
+            @test (n.name, s_path, t) in (
+                (:node_a, [s_parent], t1h1),
+                (:node_a, [s_child], t1h2),
+                (:node_b, [s_parent, s_child], t2h)
+            )
+            rhs = mop * uc * (eu - ooscf) * duration(t)
+            lhs = if duration(t) == 1
+               (
+                    + var_unit_flow[u, n, d, only(s_path), t]
+                    - mop * uc * var_units_invested_available[u, only(s_path), t]
+                )
+            else
+                (
+                    + duration(t) * var_unit_flow[u, n, d, s_parent, t]
+                    - mop * uc * (
+                        var_units_invested_available[u, s_parent, t1h1]
+                        + var_units_invested_available[u, s_child, t1h2]
+                    )
+                )
+            end
+            expected_con = @build_constraint(lhs >= rhs)
+            observed_con = constraint_object(con)
+            @test _is_constraint_equal(observed_con, expected_con)
         end
     end
 end

--- a/test/variables/variables.jl
+++ b/test/variables/variables.jl
@@ -184,15 +184,47 @@ function test_unit_online_variable_type_none()
             ["model", "instance", "roll_forward", unparse_db_value(Hour(1))],
         ]
         SpineInterface.import_data(url_in; object_parameter_values=object_parameter_values)
-        m = run_spineopt(url_in; log_level=0, optimize=true)
+        m = run_spineopt(url_in; log_level=0, optimize=false)
         var_units_on = m.ext[:spineopt].variables[:units_on]
         constraint_u_avail = m.ext[:spineopt].constraints[:units_available]
         scenarios = (stochastic_scenario(:parent), stochastic_scenario(:child))
         time_slices = time_slice(m; temporal_block=temporal_block(:hourly))
+        u = unit(:unit_ab)
         @testset for (s, t) in zip(scenarios, time_slices)
-            key = (unit(:unit_ab), s, t)
+            key = (u, s, t)
             @test_throws KeyError var_units_on[key...]
             @test_throws KeyError constraint_u_avail[key...]
+            @test SpineOpt._get_units_on(m, key...) == existing_units(unit=u)
+            @test SpineOpt._get_units_invested_available(m, key...) == 0
+        end
+    end
+    @testset "unit_online_variable_type_none_with_investments" begin
+        url_in = _test_variable_unit_setup()
+        object_parameter_values = [
+            ["unit", "unit_ab", "online_variable_type", "none"],
+            ["unit", "unit_ab", "investment_count_max_cumulative", 1],
+            ["unit", "unit_ab", "existing_units", 1],
+        ]
+        relationships = [
+            ["unit__investment_temporal_block", ["unit_ab", "hourly"]],
+            ["unit__investment_stochastic_structure", ["unit_ab", "stochastic"]],
+        ]
+        SpineInterface.import_data(
+            url_in; object_parameter_values=object_parameter_values, relationships=relationships
+        )
+        m = run_spineopt(url_in; log_level=0, optimize=false)
+        var_units_on = m.ext[:spineopt].variables[:units_on]
+        var_units_invested_available = m.ext[:spineopt].variables[:units_invested_available]
+        constraint_u_avail = m.ext[:spineopt].constraints[:units_available]
+        scenarios = (stochastic_scenario(:parent), stochastic_scenario(:child))
+        time_slices = time_slice(m; temporal_block=temporal_block(:hourly))
+        u = unit(:unit_ab)
+        @testset for (s, t) in zip(scenarios, time_slices)
+            key = (u, s, t)
+            @test_throws KeyError var_units_on[key...]
+            @test_throws KeyError constraint_u_avail[key...]
+            @test SpineOpt._get_units_on(m, u, s, t) == var_units_invested_available[key...] + existing_units(unit=u)
+            @test SpineOpt._get_units_invested_available(m, key...) == var_units_invested_available[key...]
         end
     end
 end


### PR DESCRIPTION
Fix `_get_units_on` so that it addresses the case with investments but no online variables. Similarly, implement `_get_units_invested_available` to get the investments only if available. Note that explicit `online_variable_type=:none` declarations are required to access this functionality, as otherwise SpineOpt will deduce that online variables are needed.

Fixes #1301 

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [ ] improved [type stability](https://modernjuliaworkflows.org/optimizing/#type_stability) or, when outside the scope of the pull request, at least indicated where and how the code is not properly typed
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
