### PR TITLE
Fix user Constraint fails when using representative periods

### DIFF
--- a/docs/src/how_to/retrofit_material/retrofitting_example_1.json
+++ b/docs/src/how_to/retrofit_material/retrofitting_example_1.json
@@ -4662,13 +4662,6 @@
         ],
         [
             "user_constraint",
-            "include_in_non_representative_periods",
-            false,
-            "boolean_value_list",
-            "If using representative periods, this boolean parameter determines whether or not the constraint is enforced in non-representative periods."
-        ],
-        [
-            "user_constraint",
             "is_active",
             true,
             "boolean_value_list",

--- a/examples/capacity_planning.json
+++ b/examples/capacity_planning.json
@@ -4367,13 +4367,6 @@
         ],
         [
             "user_constraint",
-            "include_in_non_representative_periods",
-            false,
-            "boolean_value_list",
-            "If using representative periods, this boolean parameter determines whether or not the constraint is enforced in non-representative periods."
-        ],
-        [
-            "user_constraint",
             "right_hand_side",
             0,
             null,

--- a/examples/multi-year_investment_with_econ_discounting_consecutives.json
+++ b/examples/multi-year_investment_with_econ_discounting_consecutives.json
@@ -4217,13 +4217,6 @@
         ],
         [
             "user_constraint",
-            "include_in_non_representative_periods",
-            false,
-            "boolean_value_list",
-            "If using representative periods, this boolean parameter determines whether or not the constraint is enforced in non-representative periods."
-        ],
-        [
-            "user_constraint",
             "right_hand_side",
             0,
             null,

--- a/examples/multi-year_investment_with_econ_discounting_milestones.json
+++ b/examples/multi-year_investment_with_econ_discounting_milestones.json
@@ -4289,13 +4289,6 @@
         ],
         [
             "user_constraint",
-            "include_in_non_representative_periods",
-            false,
-            "boolean_value_list",
-            "If using representative periods, this boolean parameter determines whether or not the constraint is enforced in non-representative periods."
-        ],
-        [
-            "user_constraint",
             "right_hand_side",
             0,
             null,

--- a/examples/multi-year_investment_without_econ_discounting.json
+++ b/examples/multi-year_investment_without_econ_discounting.json
@@ -4210,13 +4210,6 @@
         ],
         [
             "user_constraint",
-            "include_in_non_representative_periods",
-            false,
-            "boolean_value_list",
-            "If using representative periods, this boolean parameter determines whether or not the constraint is enforced in non-representative periods."
-        ],
-        [
-            "user_constraint",
             "right_hand_side",
             0,
             null,

--- a/examples/multi_stage_model_tutorial.json
+++ b/examples/multi_stage_model_tutorial.json
@@ -31053,13 +31053,6 @@
         ],
         [
             "user_constraint",
-            "include_in_non_representative_periods",
-            false,
-            "boolean_value_list",
-            "If using representative periods, this boolean parameter determines whether or not the constraint is enforced in non-representative periods."
-        ],
-        [
-            "user_constraint",
             "right_hand_side",
             0,
             null,

--- a/examples/representative_periods.json
+++ b/examples/representative_periods.json
@@ -4474,13 +4474,6 @@
         ],
         [
             "user_constraint",
-            "include_in_non_representative_periods",
-            false,
-            "boolean_value_list",
-            "If using representative periods, this boolean parameter determines whether or not the constraint is enforced in non-representative periods."
-        ],
-        [
-            "user_constraint",
             "right_hand_side",
             0,
             null,

--- a/examples/reserves.json
+++ b/examples/reserves.json
@@ -2904,13 +2904,6 @@
         ],
         [
             "user_constraint",
-            "include_in_non_representative_periods",
-            false,
-            "boolean_value_list",
-            "If using representative periods, this boolean parameter determines whether or not the constraint is enforced in non-representative periods."
-        ],
-        [
-            "user_constraint",
             "right_hand_side",
             0,
             null,

--- a/examples/rolling_horizon.json
+++ b/examples/rolling_horizon.json
@@ -2904,13 +2904,6 @@
         ],
         [
             "user_constraint",
-            "include_in_non_representative_periods",
-            false,
-            "boolean_value_list",
-            "If using representative periods, this boolean parameter determines whether or not the constraint is enforced in non-representative periods."
-        ],
-        [
-            "user_constraint",
             "right_hand_side",
             0,
             null,

--- a/examples/simple_system.json
+++ b/examples/simple_system.json
@@ -2904,13 +2904,6 @@
         ],
         [
             "user_constraint",
-            "include_in_non_representative_periods",
-            false,
-            "boolean_value_list",
-            "If using representative periods, this boolean parameter determines whether or not the constraint is enforced in non-representative periods."
-        ],
-        [
-            "user_constraint",
             "right_hand_side",
             0,
             null,

--- a/examples/stochastic.json
+++ b/examples/stochastic.json
@@ -4197,13 +4197,6 @@
         ],
         [
             "user_constraint",
-            "include_in_non_representative_periods",
-            false,
-            "boolean_value_list",
-            "If using representative periods, this boolean parameter determines whether or not the constraint is enforced in non-representative periods."
-        ],
-        [
-            "user_constraint",
             "right_hand_side",
             0,
             null,

--- a/examples/unit_commitment.json
+++ b/examples/unit_commitment.json
@@ -2904,13 +2904,6 @@
         ],
         [
             "user_constraint",
-            "include_in_non_representative_periods",
-            false,
-            "boolean_value_list",
-            "If using representative periods, this boolean parameter determines whether or not the constraint is enforced in non-representative periods."
-        ],
-        [
-            "user_constraint",
             "right_hand_side",
             0,
             null,

--- a/src/constraints/constraint_user_constraint.jl
+++ b/src/constraints/constraint_user_constraint.jl
@@ -264,7 +264,12 @@ function constraint_user_constraint_indices(m::Model)
         (user_constraint=uc, stochastic_path=path, t=t)
         for uc in user_constraint()
         for (t, path) in t_lowest_resolution_path(
-            m, Iterators.flatten(user_constraint_all_indices(m; user_constraint=uc))
+            m,
+            Iterators.flatten(
+                user_constraint_all_indices(
+                    m; user_constraint=uc, temporal_block=temporal_block(is_representative=true)
+                )
+            ),
         )
         if _is_representative(t)
     )

--- a/src/constraints/constraint_user_constraint.jl
+++ b/src/constraints/constraint_user_constraint.jl
@@ -266,7 +266,7 @@ function constraint_user_constraint_indices(m::Model)
         for (t, path) in t_lowest_resolution_path(
             m, Iterators.flatten(user_constraint_all_indices(m; user_constraint=uc))
         )
-        if _is_representative(t) || include_in_non_representative_periods(user_constraint=uc)
+        if _is_representative(t)
     )
 end
 

--- a/src/convenience_functions.jl
+++ b/src/convenience_functions.jl
@@ -187,7 +187,6 @@ const has_ptdf = Parameter(:has_ptdf)
 const has_state = Parameter(:has_state)
 const has_switched_variable = Parameter(:has_switched_variable)
 const has_voltage_angle = Parameter(:has_voltage_angle)
-const include_in_non_representative_periods = Parameter(:include_in_non_representative_periods)
 const initial_binary_gas_connection_flow = Parameter(:initial_binary_gas_connection_flow)
 const initial_connection_flow = Parameter(:initial_connection_flow)
 const initial_connection_intact_flow = Parameter(:initial_connection_intact_flow)
@@ -568,7 +567,6 @@ export has_ptdf
 export has_state
 export has_switched_variable
 export has_voltage_angle
-export include_in_non_representative_periods
 export initial_binary_gas_connection_flow
 export initial_connection_flow
 export initial_connection_intact_flow

--- a/src/data_structure/temporal_structure.jl
+++ b/src/data_structure/temporal_structure.jl
@@ -803,7 +803,7 @@ function _repr_t_coefs(m, t)
 end
 
 function _is_representative(t)
-    any(is_representative(temporal_block=blk) for blk in blocks(t))
+    any(is_representative(temporal_block=blk, _default=false) for blk in blocks(t))
 end
 
 function represented_time_slices(m)

--- a/templates/spineopt_template.json
+++ b/templates/spineopt_template.json
@@ -326,8 +326,7 @@
         ["unit", "units_unavailable", 0, null, "Represents the number of units out of service"],
         ["user_constraint", "constraint_sense", "==", "constraint_sense_list", "A selector for the sense of the `user_constraint`."],
         ["user_constraint", "right_hand_side", 0.0, null, "The right-hand side, constant term in a `user_constraint`. Can be time-dependent and used e.g. for complicated efficiency approximations."],
-        ["user_constraint", "user_constraint_slack_penalty", null, null, "A penalty for violating a user constraint."],
-        ["user_constraint", "include_in_non_representative_periods", false, "boolean_value_list", "If using representative periods, this boolean parameter determines whether or not the constraint is enforced in non-representative periods."]
+        ["user_constraint", "user_constraint_slack_penalty", null, null, "A penalty for violating a user constraint."]
     ],
     "relationship_parameters": [
         ["connection__from_node", "connection_capacity", null, null, "Limits the `connection_flow` variable from the `from_node`. `from_node` can be a group of `nodes`, in which case the sum of the `connection_flow` is constrained."],

--- a/test/constraints/constraint_user_constraint.jl
+++ b/test/constraints/constraint_user_constraint.jl
@@ -279,6 +279,113 @@
     end
 end
 
+function _representative_period_user_constraint_test_data(; with_investment=false)
+    repr_periods_mapping = Map([DateTime(2000, 1, 1), DateTime(2000, 1, 2)], [[1], [1]])
+    objects = [
+        ["model", "instance"],
+        ["temporal_block", "operations"],
+        ["temporal_block", "rp1"],
+        ["stochastic_structure", "deterministic"],
+        ["stochastic_scenario", "realisation"],
+        ["node", "power_node"],
+        ["unit", "power_plant_a"],
+        ["unit", "power_plant_b"],
+        ["user_constraint", "emission_limit"],
+    ]
+    relationships = [
+        ["model__default_temporal_block", ["instance", "operations"]],
+        ["model__default_temporal_block", ["instance", "rp1"]],
+        ["model__default_stochastic_structure", ["instance", "deterministic"]],
+        ["stochastic_structure__stochastic_scenario", ["deterministic", "realisation"]],
+        ["unit__to_node", ["power_plant_a", "power_node"]],
+        ["unit__to_node", ["power_plant_b", "power_node"]],
+        ["unit__to_node__user_constraint", ["power_plant_a", "power_node", "emission_limit"]],
+        ["unit__to_node__user_constraint", ["power_plant_b", "power_node", "emission_limit"]],
+    ]
+    object_parameter_values = [
+        ["model", "instance", "model_start", unparse_db_value(DateTime(2000, 1, 1))],
+        ["model", "instance", "model_end", unparse_db_value(DateTime(2000, 1, 3))],
+        ["model", "instance", "duration_unit", "hour"],
+        ["model", "instance", "model_type", "spineopt_standard"],
+        ["model", "instance", "db_mip_solver", "HiGHS.jl"],
+        ["model", "instance", "db_lp_solver", "HiGHS.jl"],
+        ["temporal_block", "operations", "resolution", unparse_db_value(Day(1))],
+        ["temporal_block", "operations", "representative_periods_mapping", unparse_db_value(repr_periods_mapping)],
+        ["temporal_block", "rp1", "resolution", unparse_db_value(Hour(1))],
+        ["temporal_block", "rp1", "block_start", unparse_db_value(DateTime(2000, 1, 1))],
+        ["temporal_block", "rp1", "block_end", unparse_db_value(DateTime(2000, 1, 2))],
+        ["temporal_block", "rp1", "representative_period_index", 1],
+        ["user_constraint", "emission_limit", "constraint_sense", :>=],
+    ]
+    relationship_parameter_values = [
+        [
+            "unit__to_node__user_constraint",
+            ["power_plant_a", "power_node", "emission_limit"],
+            "unit_flow_coefficient",
+            1,
+        ],
+        [
+            "unit__to_node__user_constraint",
+            ["power_plant_b", "power_node", "emission_limit"],
+            "unit_flow_coefficient",
+            2,
+        ],
+    ]
+    if with_investment
+        push!(objects, ["temporal_block", "investments"])
+        append!(
+            relationships,
+            [
+                ["model__default_investment_temporal_block", ["instance", "investments"]],
+                ["model__default_investment_stochastic_structure", ["instance", "deterministic"]],
+            ],
+        )
+        append!(
+            object_parameter_values,
+            [
+                ["temporal_block", "investments", "resolution", unparse_db_value(Day(2))],
+                ["unit", "power_plant_a", "candidate_units", 1],
+            ],
+        )
+    end
+    Dict(
+        :objects => objects,
+        :relationships => relationships,
+        :object_parameter_values => object_parameter_values,
+        :relationship_parameter_values => relationship_parameter_values,
+    )
+end
+
+function _test_representative_period_user_constraint_indices(; with_investment=false)
+    url_in = "sqlite://"
+    _load_test_data(url_in, _representative_period_user_constraint_test_data(; with_investment=with_investment))
+    m = run_spineopt(url_in; log_level=0, optimize=false)
+    constraint = m.ext[:spineopt].constraints[:user_constraint]
+    representative_t = time_slice(m; temporal_block=temporal_block(:rp1))
+    represented_t = Set(time_slice(m; temporal_block=temporal_block(:operations)))
+    observed_t = Set(ind.t for ind in keys(constraint))
+    @test length(constraint) == length(representative_t)
+    @test observed_t == Set(representative_t)
+    @test isempty(intersect(observed_t, represented_t))
+    @fetch unit_flow = m.ext[:spineopt].variables
+    uc = user_constraint(:emission_limit)
+    s = stochastic_scenario(:realisation)
+    n = node(:power_node)
+    d = direction(:to_node)
+    for t in representative_t
+        observed_con = constraint_object(constraint[(user_constraint=uc, stochastic_path=[s], t=t)])
+        expected_con = @build_constraint(
+            unit_flow[unit(:power_plant_a), n, d, s, t] + 2 * unit_flow[unit(:power_plant_b), n, d, s, t] >= 0
+        )
+        @test _is_constraint_equal(observed_con, expected_con)
+    end
+end
+
+@testset "representative period user constraints" begin
+    _test_representative_period_user_constraint_indices()
+    _test_representative_period_user_constraint_indices(; with_investment=true)
+end
+
 @testset "more user constraints" begin
     url_in = "sqlite://"
     test_data = Dict(


### PR DESCRIPTION
This pull request includes the following changes:

**Removal of `include_in_non_representative_periods` parameter:**

* The `include_in_non_representative_periods` parameter is removed from all example JSON files, documentation, and the main template, so it is no longer available as a user-configurable option. 

**Codebase updates for constraint enforcement:**

* The function `constraint_user_constraint_indices` is updated to only enforce user constraints in representative periods in the lowest resolution of the variables involved by filtering user-constraint candidate indices to representative temporal blocks before t_lowest_resolution_path.
* The `include_in_non_representative_periods` parameter and its export are removed from `src/convenience_functions.jl`.
* The `_is_representative` function is updated to default to `false` unless explicitly set, ensuring correct identification of representative periods.

**Testing updates:**

* New tests are added to verify that user constraints are only enforced in representative periods in the lowest resolution, including scenarios with and without investment.

Fixes #1314

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] improved [type stability](https://modernjuliaworkflows.org/optimizing/#type_stability) or, when outside the scope of the pull request, at least indicated where and how the code is not properly typed
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
