### PR TITLE
Avoid calling termination_status(m) outside optimize_model()

### DIFF
--- a/src/run_spineopt.jl
+++ b/src/run_spineopt.jl
@@ -186,7 +186,7 @@ function _run_spineopt(
             end
         end
         model_status = Dict(
-            string(_model_name(model)) => string(termination_status(model))
+            string(_model_name(model)) => string(get(model.ext[:spineopt].extras, :termination_status, ""))
             for model in models
         )
         if !isempty(model_status)

--- a/src/run_spineopt_basic.jl
+++ b/src/run_spineopt_basic.jl
@@ -743,6 +743,7 @@ function optimize_model!(
     model_name = _model_name(m)
     @timelog log_level 0 "Optimizing $model_name..." stats optimize!(m)
     termination_st = termination_status(m)
+    m.ext[:spineopt].extras[:termination_status] = termination_st
     if is_solved_and_feasible(m; allow_almost = true) || (termination_st == MOI.TIME_LIMIT)
         if result_count(m) > 0
             solution_type = termination_st == MOI.OPTIMAL ? "Optimal" : "Feasible"


### PR DESCRIPTION
Avoid calling termination_status(m) outside optimize_model() for more robust behaviour

(description of changes)

Fixes # (issue)

## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Unit tests have been added/updated accordingly
- [ ] improved [type stability](https://modernjuliaworkflows.org/optimizing/#type_stability) or, when outside the scope of the pull request, at least indicated where and how the code is not properly typed
- [ ] Code has been formatted according to SpineOpt's style
- [ ] Unit tests pass
