### PR TITLE
ci: add selectable benchmark workflow

### DIFF
--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -29,12 +29,17 @@ on:
 
 permissions:
   contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
   benchmark:
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      contains(github.event.pull_request.labels.*.name, 'benchmark')
+      (
+        contains(github.event.pull_request.labels.*.name, 'benchmark') &&
+        github.event.pull_request.head.repo.full_name == github.repository
+      )
     runs-on: ubuntu-latest
     env:
       SPINEOPT_BENCHMARK_EXAMPLE: ${{ inputs.example || 'synthetic' }}
@@ -58,12 +63,61 @@ jobs:
           if [ "$SPINEOPT_BENCHMARK_EXAMPLE" != "synthetic" ]; then
             test -f "$SPINEOPT_BENCHMARK_EXAMPLE"
           fi
+      - name: Find benchmark comment
+        if: github.event_name == 'pull_request'
+        uses: peter-evans/find-comment@v4
+        id: find-benchmark-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: github-actions[bot]
+          body-includes: Benchmark Results
+      - name: Mark benchmark in progress
+        if: github.event_name == 'pull_request'
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          comment-id: ${{ steps.find-benchmark-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ### Benchmark Results
+
+            Benchmark in progress...
+          edit-mode: replace
       - name: Run benchmark suite
         run: |
           julia --project=benchmark -e 'using BenchmarkTools; include("benchmark/benchmarks.jl"); run(SUITE; verbose=true)' \
             | tee benchmark-results.txt
+      - name: Prepare benchmark comment
+        if: always() && github.event_name == 'pull_request'
+        env:
+          BENCHMARK_STATUS: ${{ job.status }}
+        run: |
+          {
+            echo '### Benchmark Results'
+            echo
+            if [ "$BENCHMARK_STATUS" = "success" ]; then
+              echo 'Benchmark completed successfully. Raw output:'
+            else
+              echo 'Benchmark did not complete successfully. See the workflow logs for details.'
+            fi
+            if [ -f benchmark-results.txt ]; then
+              echo
+              echo '```text'
+              head -c 60000 benchmark-results.txt
+              echo
+              echo '```'
+            fi
+          } > benchmark-comment.md
       - name: Upload benchmark results
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: spineopt-benchmark-results
           path: benchmark-results.txt
+      - name: Publish benchmark comment
+        if: always() && github.event_name == 'pull_request'
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          comment-id: ${{ steps.find-benchmark-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body-path: benchmark-comment.md
+          edit-mode: replace

--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -1,0 +1,69 @@
+name: Benchmarks
+
+on:
+  pull_request:
+    branches:
+      - master
+    types: [opened, synchronize, reopened, labeled]
+  workflow_dispatch:
+    inputs:
+      example:
+        description: Example data set to benchmark
+        required: true
+        default: synthetic
+        type: choice
+        options:
+          - synthetic
+          - examples/simple_system.json
+          - examples/6_unit_system.json
+          - examples/capacity_planning.json
+          - examples/multi-year_investment_with_econ_discounting_consecutives.json
+          - examples/multi-year_investment_with_econ_discounting_milestones.json
+          - examples/multi-year_investment_without_econ_discounting.json
+          - examples/multi_stage_model_tutorial.json
+          - examples/representative_periods.json
+          - examples/reserves.json
+          - examples/rolling_horizon.json
+          - examples/stochastic.json
+          - examples/unit_commitment.json
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'benchmark')
+    runs-on: ubuntu-latest
+    env:
+      SPINEOPT_BENCHMARK_EXAMPLE: ${{ inputs.example || 'synthetic' }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: "1"
+      - uses: julia-actions/cache@v2
+      - name: Install spinedb_api
+        run: julia ./.install_spinedb_api.jl
+        env:
+          PYTHON: python
+      - name: Instantiate benchmark environment
+        run: julia --project=benchmark -e 'using Pkg; Pkg.instantiate()'
+      - name: Validate benchmark selection
+        run: |
+          if [ "$SPINEOPT_BENCHMARK_EXAMPLE" != "synthetic" ]; then
+            test -f "$SPINEOPT_BENCHMARK_EXAMPLE"
+          fi
+      - name: Run benchmark suite
+        run: |
+          julia --project=benchmark -e 'using BenchmarkTools; include("benchmark/benchmarks.jl"); run(SUITE; verbose=true)' \
+            | tee benchmark-results.txt
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: spineopt-benchmark-results
+          path: benchmark-results.txt

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SpineInterface = "0cda1612-498a-11e9-3c92-77fa82595a4f"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,5 +1,6 @@
 using BenchmarkTools
 using Dates
+using JSON
 using SpineInterface
 using SpineOpt
 using Graphs
@@ -175,16 +176,33 @@ function setup(; number_of_weeks=1, n_count=50, add_meshed_network=true, add_inv
     return url_in, url_out
 end
 
-SUITE["main"] = BenchmarkGroup()
+const configured_example = get(ENV, "SPINEOPT_BENCHMARK_EXAMPLE", "synthetic")
 
-url_in_basic, url_out_basic =
-    setup(number_of_weeks=1, n_count=2, add_meshed_network=true, add_investment=false, add_rolling=false)
-# url_in_invest, url_out_invest = setup(number_of_weeks=1, n_count=2, add_investment=true, add_rolling=false)
-# url_in_roll, url_out_roll = setup(number_of_weeks=3, n_count=50, add_investment=false, add_rolling=true)
+function add_example_benchmark(path::AbstractString)
+    example_path = isabspath(path) ? path : normpath(joinpath(@__DIR__, "..", path))
+    isfile(example_path) || error("Benchmark example not found: $example_path")
+    example = JSON.parsefile(example_path)
+    label = splitext(basename(example_path))[1]
+    SUITE["examples"] = BenchmarkGroup()
+    SUITE["examples", label] =
+        @benchmarkable run_spineopt($example, nothing; log_level=0, optimize=false) samples = 1 evals = 1 seconds = Inf
+end
 
-SUITE["main", "run_spineopt", "basic"] =
-    @benchmarkable run_spineopt($url_in_basic, $url_out_basic; log_level=3, optimize=false) samples = 1 evals = 1 seconds =
-        Inf
+if configured_example == "synthetic"
+    SUITE["main"] = BenchmarkGroup()
+
+    url_in_basic, url_out_basic =
+        setup(number_of_weeks=1, n_count=2, add_meshed_network=true, add_investment=false, add_rolling=false)
+    # url_in_invest, url_out_invest = setup(number_of_weeks=1, n_count=2, add_investment=true, add_rolling=false)
+    # url_in_roll, url_out_roll = setup(number_of_weeks=3, n_count=50, add_investment=false, add_rolling=true)
+
+    SUITE["main", "run_spineopt", "basic"] =
+        @benchmarkable run_spineopt($url_in_basic, $url_out_basic; log_level=3, optimize=false) samples = 1 evals = 1 seconds =
+            Inf
+else
+    add_example_benchmark(configured_example)
+end
+
 # SUITE["main", "run_spineopt", "investment"] =
 #     @benchmarkable run_spineopt($url_in_invest, $url_out_invest; log_level=3, optimize=false) samples = 3 evals = 1 seconds =
 #         Inf


### PR DESCRIPTION
Fixes #1000

### Summary
- Add a benchmark workflow that runs on pull requests labeled benchmark and through workflow_dispatch.
- Support the synthetic benchmark and each JSON case study in examples through a selectable input.
- Keep the existing synthetic suite as the default while allowing SPINEOPT_BENCHMARK_EXAMPLE to select a case study.
- Upload benchmark output as an artifact for review without requiring write access from forked pull requests.\n\n

### Validation
- git diff --check passed
- Workflow YAML parsed successfully
- Every workflow example choice was checked against the repository
- Julia is not installed locally, so the Julia instantiate and benchmark run are left for hosted CI

## Checklist before merging
- [x] Documentation is up-to-date
- [ ] Unit tests have been added/updated accordingly
- [x] Type stability is outside the scope of this workflow/setup change
- [ ] Unit tests pass locally (Julia is unavailable in this environment)